### PR TITLE
Adding SIMD optmizations

### DIFF
--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <span>
 
 #include "incbin.h"

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -11,7 +11,6 @@
 #include <array>
 #include <cassert>
 #include <cstdint>
-#include <cstring>
 #include <span>
 #include <vector>
 

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -14,6 +14,7 @@
 #include <span>
 #include <vector>
 
+#include "simd.h"
 #include "types.h"
 
 class Position;
@@ -29,6 +30,11 @@ constexpr int SCALE = 400;
 constexpr int QA = 255;
 constexpr int QB = 64;
 constexpr int QAB = QA * QB;
+
+#ifdef USE_SIMD
+const vepi16 QZERO = vepi16_zero();
+const vepi16 QONE = vepi16_set(QA);
+#endif
 
 struct alignas(64) Network {
     std::array<int16_t, INPUT_LAYER_SIZE * HIDDEN_LAYER_SIZE> hidden_weights;
@@ -73,8 +79,8 @@ class NNUE {
 
     constexpr int32_t crelu(const int32_t &input) const;
     constexpr int32_t screlu(const int32_t &input) const;
-    ScoreType weight_sum_reduction(const std::array<int16_t, HIDDEN_LAYER_SIZE> &player,
-                                   const std::array<int16_t, HIDDEN_LAYER_SIZE> &adversary) const;
+    ScoreType flatten_screlu_and_affine(const std::array<int16_t, HIDDEN_LAYER_SIZE> &player,
+                                        const std::array<int16_t, HIDDEN_LAYER_SIZE> &adversary) const;
 
     std::vector<Accumulator> m_accumulators; //!< Stack with accumulators
 };

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -11,6 +11,7 @@
 #include <cassert>
 #include <cctype>
 #include <cstdint>
+#include <cstring>
 #include <iostream>
 
 #include "attacks.h"

--- a/src/simd.h
+++ b/src/simd.h
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2024 Eduardo Marinho <eduardo.nestor.marinho@proton.me>
+ *
+ *  Licensed under the MIT License.
+ *  See the LICENSE file in the project root for more information.
+ */
+
+#ifndef SIMD_H
+#define SIMD_H
+
+#include <cstdint>
+
+#ifdef USE_AVX2
+
+#include <immintrin.h>
+
+constexpr int REGISTER_SIZE = 16;
+
+using vepi16 = __m256i;
+using vepi32 = __m256i;
+
+inline vepi16 vepi16_zero() { return _mm256_setzero_si256(); }
+inline vepi32 vepi32_zero() { return _mm256_setzero_si256(); }
+inline vepi16 vepi16_set(const int16_t v) { return _mm256_set1_epi16(v); }
+inline vepi16 vepi16_load(const int16_t* data) { return _mm256_load_si256(reinterpret_cast<const vepi16*>(data)); }
+inline vepi16 vepi16_add(const vepi16 a, const vepi16 b) { return _mm256_add_epi16(a, b); }
+inline vepi16 vepi16_sub(const vepi16 a, const vepi16 b) { return _mm256_sub_epi16(a, b); }
+inline vepi16 vepi16_mult(const vepi16 a, const vepi16 b) { return _mm256_mullo_epi16(a, b); }
+inline vepi32 vepi16_madd(const vepi16 a, const vepi16 b) { return _mm256_madd_epi16(a, b); }
+inline vepi32 vepi32_add(const vepi32 a, const vepi32 b) { return _mm256_add_epi32(a, b); }
+
+inline vepi16 vepi16_max(const vepi16 vec, const vepi16 max) { return _mm256_max_epi16(vec, max); }
+inline vepi16 vepi16_min(const vepi16 vec, const vepi16 min) { return _mm256_min_epi16(vec, min); }
+inline vepi16 vepi16_clamp(vepi16 vec, const vepi16 min, const vepi16 max) {
+    return vepi16_max(vepi16_min(vec, max), min);
+}
+inline int32_t vepi32_reduce_add(const vepi32 vec) {
+    // Add upper 128 bits and lower 128 bits together
+    __m128i low = _mm256_castsi256_si128(vec);
+    __m128i high = _mm256_extracti128_si256(vec, 1);
+    __m128i sum128 = _mm_add_epi32(low, high);
+
+    // Reduce sum128 downs to i32 using shuffle and add
+    __m128i tmp = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_SHUFFLE(2, 3, 0, 1)));
+    tmp = _mm_add_epi32(tmp, _mm_shuffle_epi32(tmp, _MM_SHUFFLE(1, 0, 3, 2)));
+
+    return _mm_cvtsi128_si32(tmp);
+}
+
+#elif USE_AVX512
+#include <immintrin.h>
+constexpr int REGISTER_SIZE = 32;
+
+using vepi16 = __m512i;
+using vepi32 = __m512i;
+
+inline vepi16 vepi16_zero() { return _mm512_setzero_si512(); }
+inline vepi32 vepi32_zero() { return _mm512_setzero_si512(); }
+inline vepi16 vepi16_set(const int16_t v) { return _mm512_set1_epi16(v); }
+inline vepi16 vepi16_load(const int16_t* data) { return _mm512_load_si512(reinterpret_cast<const vepi16*>(data)); }
+inline vepi16 vepi16_add(const vepi16 a, const vepi16 b) { return _mm512_add_epi16(a, b); }
+inline vepi16 vepi16_sub(const vepi16 a, const vepi16 b) { return _mm512_sub_epi16(a, b); }
+inline vepi16 vepi16_mult(const vepi16 a, const vepi16 b) { return _mm512_mullo_epi16(a, b); }
+inline vepi32 vepi16_madd(const vepi16 a, const vepi16 b) { return _mm512_madd_epi16(a, b); }
+inline vepi32 vepi32_add(const vepi32 a, const vepi32 b) { return _mm512_add_epi32(a, b); }
+
+inline vepi16 vepi16_max(const vepi16 vec, const vepi16 max) { return _mm512_max_epi16(vec, max); }
+inline vepi16 vepi16_min(const vepi16 vec, const vepi16 min) { return _mm512_min_epi16(vec, min); }
+inline vepi16 vepi16_clamp(vepi16 vec, const vepi16 min, const vepi16 max) {
+    return vepi16_max(vepi16_min(vec, max), min);
+}
+inline int32_t vepi32_reduce_add(const vepi32 vec) { return _mm512_reduce_add_epi32(vec); }
+
+#endif
+
+#endif // #ifndef SIMD_H


### PR DESCRIPTION
Results of minkeSIMD vs minkeMain (10+0.1, NULL, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 27.31 +/- 9.64, nElo: 48.36 +/- 16.99
LOS: 100.00 %, DrawRatio: 48.19 %, PairsRatio: 1.77
Games: 1606, Wins: 442, Losses: 316, Draws: 848, Points: 866.0 (53.92 %)
Ptnml(0-2): [14, 136, 387, 242, 24], WL/DD Ratio: 0.65
LLR: 2.95 (100.3%) (-2.94, 2.94) [0.00, 5.00]
SPRT ([0.00, 5.00]) completed - H1 was accepted