### PR TITLE
Improve pseudo-legal move generation by tracking pinned pieces and king attackers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,67 +1,71 @@
 cmake_minimum_required(VERSION 3.10)
-project(Minke)
+project(
+  Minke
+  VERSION 2.0
+  LANGUAGES CXX)
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 20)
 
 # Sources files
 file(GLOB SOURCES src/*.cpp)
 
-# Common flags
-set(NET_PATH "${CMAKE_SOURCE_DIR}/src/minke.bin")
-set(COMMON_COMPILE_FLAGS "-DNET_PATH=\"${NET_PATH}\"")
-set(COMMON_LINK_FLAGS "")
+add_executable(minke ${SOURCES})
 
+string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type)
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-elseif(CMAKE_BUILD_TYPE STREQUAL "Datagen")
-  set(COMMON_COMPILE_FLAGS ${COMMON_COMPILE_FLAGS} "-DDATAGEN_BUILD")
-  set(CMAKE_BUILD_TYPE Release)
+  set(buildtype release)
+elseif(build_type STREQUAL "datagen")
+  target_compile_definitions(minke PRIVATE DATAGEN_BUILD)
+  set(buildtype release)
 endif()
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(COMMON_COMPILE_FLAGS
-      ${COMMON_COMPILE_FLAGS}
-      "-Wall"
-      "-Wshadow"
-      "-Wsign-compare"
-      "-Wold-style-cast"
-      "-Wpedantic"
-      "-Wextra"
-      "-Wcast-align"
-      "-Wcast-qual"
-      "-g")
-elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
-  set(COMMON_COMPILE_FLAGS ${COMMON_COMPILE_FLAGS} "-O3" "-funroll-loops"
-                           "-DNDEBUG")
-  set(COMMON_LINK_FLAGS ${COMMON_COMPILE_FLAGS} "-fuse-ld=lld" "-flto")
+if(release STREQUAL "debug")
+  target_compile_options(
+    minke
+    PRIVATE -Wall
+            -Wshadow
+            -Wsign-compare
+            -Wold-style-cast
+            -Wpedantic
+            -Wextra
+            -Wcast-align
+            -Wcast-qual
+            -g)
+elseif(build_type STREQUAL "release")
+  target_compile_options(minke PRIVATE -O3 -funroll-loops -DNDEBUG)
+  target_link_options(minke PRIVATE -fuse-ld=lld -flto)
 endif()
 
 if(WIN32)
-  set(COMMON_COMPILE_FLAGS ${COMMON_COMPILE_FLAGS} "-static")
+  target_link_options(minke PRIVATE -static)
 elseif(UNIX)
-  set(COMMON_LINK_FLAGS ${COMMON_LINK_FLAGS} "-pthread")
+  find_package(Threads REQUIRED)
+  target_link_libraries(minke PRIVATE Threads::Threads)
 endif()
 
-# Make init.cpp recompiled when NET_PATH has changed
+# Define NET_PATH and make init.cpp recompiled when NET_PATH has changed
+set(NET_PATH "${CMAKE_SOURCE_DIR}/src/minke.bin")
+target_compile_definitions(minke PRIVATE NET_PATH=\"${NET_PATH}\")
 set_property(
   SOURCE ${CMAKE_SOURCE_DIR}/src/init.cpp
   APPEND
   PROPERTY OBJECT_DEPENDS ${NET_PATH})
 
-function(add_minke_variant name flags)
-  add_executable(minke-${name} ${SOURCES})
-  target_compile_options(minke-${name} PRIVATE ${COMMON_COMPILE_FLAGS} ${flags})
-  target_link_options(minke-${name} PRIVATE ${COMMON_LINK_FLAGS})
-endfunction()
-
-if(APPLE)
-  add_minke_variant(
-    apple-silicon
-    "-march=armv8.5-a;-mcpu=apple-m1;-DUSE_SIMD;-DUSE_APPLE_SILICON")
+# Build variants
+string(TOLOWER "${CMAKE_BUILD_ARCH}" arch)
+if(arch STREQUAL "apple-silicon")
+  target_compile_definitions(minke PRIVATE USE_SIMD USE_ARM_NEON)
+  target_compile_options(minke PRIVATE -march=armv8.5-a -mcpu=apple-m1)
+elseif(arch STREQUAL "avx2")
+  target_compile_definitions(minke PRIVATE USE_SIMD USE_AVX2)
+  target_compile_options(minke PRIVATE -mavx2 -mbmi -mfma)
+elseif(arch STREQUAL "bmi2")
+  target_compile_definitions(minke PRIVATE USE_AVX2 USE_SIMD)
+  target_compile_options(minke PRIVATE -mavx2 -mbmi -mbmi2 -mfma)
+elseif(arch STREQUAL "avx512")
+  target_compile_definitions(minke PRIVATE USE_AVX512 USE_SIMD)
+  target_compile_options(minke PRIVATE -mavx512f -mavx512bw -mfma)
 else()
-  add_minke_variant(native "-march=native")
-  add_minke_variant(avx2 "-DUSE_AVX2;-DUSE_SIMD;-mavx2;-mbmi;-mfma")
-  add_minke_variant(bmi2 "-DUSE_AVX2;-DUSE_SIMD;-mavx2;-mbmi;-mbmi2;-mfma")
-  add_minke_variant(avx512 "-DUSE_AVX512;-DUSE_SIMD;-mavx512f;-mavx512bw;-mfma")
+  target_compile_options(minke PRIVATE -march=native)
 endif()

--- a/src/attacks.h
+++ b/src/attacks.h
@@ -37,6 +37,8 @@ extern Bitboard king_attacks[64];
 extern Bitboard bishop_attacks[64][512];
 extern Bitboard rook_attacks[64][4096];
 
+extern Bitboard between_squares[64][64];
+
 void init_magic_table(PieceType piece_type);
 
 Bitboard generate_bishop_mask(Square sq);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -26,12 +26,14 @@ int LMR_TABLE[64][64];
 int LMP_TABLE[2][LMP_DEPTH];
 HashKeys hash_keys;
 Network network;
+Bitboard between_squares[64][64];
 
 void init_all() {
     init_search_params();
     init_network_params();
     init_hash_keys();
     init_magic_attack_tables();
+    init_between_squares();
 }
 
 void init_search_params() {
@@ -101,5 +103,21 @@ void init_magic_attack_tables() {
         pawn_attacks[BLACK][sq] = generate_pawn_attacks(sq, BLACK);
         knight_attacks[sq] = generate_knight_attacks(sq);
         king_attacks[sq] = generate_king_attacks(sq);
+    }
+}
+
+void init_between_squares() {
+    for (int sqi1 = a1; sqi1 <= h8; ++sqi1) {
+        for (int sqi2 = a1; sqi2 <= h8; ++sqi2) {
+            Square sq1 = static_cast<Square>(sqi1);
+            Square sq2 = static_cast<Square>(sqi2);
+            Bitboard occ1 = (1ULL << sq1);
+            Bitboard occ2 = (1ULL << sq2);
+            if (get_bishop_attacks(sq1, 0) & occ2) {
+                between_squares[sq1][sq2] = get_bishop_attacks(sq1, occ2) & get_bishop_attacks(sq2, occ1);
+            } else if (get_rook_attacks(sq1, 0) & occ2) {
+                between_squares[sq1][sq2] = get_rook_attacks(sq1, occ2) & get_rook_attacks(sq2, occ1);
+            }
+        }
     }
 }

--- a/src/init.h
+++ b/src/init.h
@@ -18,4 +18,6 @@ void init_hash_keys();
 
 void init_magic_attack_tables();
 
+void init_between_squares();
+
 #endif // #ifndef INIT_H

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -16,7 +16,8 @@
 #include "types.h"
 #include "utils.h"
 
-static inline ScoredMove* gen_pawn_captures(ScoredMove* moves, const Position& position, const int& capture_offset) {
+static inline ScoredMove* gen_pawn_captures(ScoredMove* moves, const Position& position, const Bitboard& destination,
+                                            const int& capture_offset) {
     assert(capture_offset == NORTH_WEST || capture_offset == NORTH_EAST || capture_offset == SOUTH_WEST ||
            capture_offset == SOUTH_EAST);
 
@@ -25,7 +26,7 @@ static inline ScoredMove* gen_pawn_captures(ScoredMove* moves, const Position& p
     if (!pawns) // No pawns can capture
         return moves;
 
-    Bitboard enemy_targets = position.get_occupancy(position.get_adversary());
+    Bitboard enemy_targets = position.get_occupancy(position.get_adversary()) & destination;
     Bitboard captures = shift(pawns, capture_offset) & enemy_targets;
     Bitboard capture_promotions = captures & RANK_MASKS[get_pawn_promotion_rank(position.get_stm())];
     Bitboard capture_no_promotions = captures & ~capture_promotions;
@@ -43,7 +44,8 @@ static inline ScoredMove* gen_pawn_captures(ScoredMove* moves, const Position& p
     return moves;
 }
 
-static inline ScoredMove* gen_pawn_moves(ScoredMove* moves, const Position& position, const MoveGenType gen_type) {
+static inline ScoredMove* gen_pawn_moves(ScoredMove* moves, const Position& position, const Bitboard& destination,
+                                         const MoveGenType gen_type) {
     Color stm = position.get_stm();
     Color adversary = position.get_adversary();
     int pawn_offset = get_pawn_offset(stm);
@@ -61,16 +63,20 @@ static inline ScoredMove* gen_pawn_moves(ScoredMove* moves, const Position& posi
         Bitboard double_push =
             shift(single_push_no_promotion, pawn_offset) & empty_targets & RANK_MASKS[(stm == WHITE ? 3 : 4)];
 
+        single_push_no_promotion &= destination;
         while (single_push_no_promotion) {
             Square to = poplsb(single_push_no_promotion);
             *moves++ = {Move(static_cast<Square>(to - pawn_offset), to, REGULAR), 0};
         }
+
+        double_push &= destination;
         while (double_push) {
             Square to = poplsb(double_push);
             *moves++ = {Move(static_cast<Square>(to - 2 * pawn_offset), to, REGULAR), 0};
         }
     }
     if (gen_type & NOISY) {
+        promotion &= destination;
         while (promotion) {
             Square to = poplsb(promotion);
             *moves++ = {Move(static_cast<Square>(to - pawn_offset), to, PAWN_PROMOTION_QUEEN), 0};
@@ -79,8 +85,8 @@ static inline ScoredMove* gen_pawn_moves(ScoredMove* moves, const Position& posi
             *moves++ = {Move(static_cast<Square>(to - pawn_offset), to, PAWN_PROMOTION_BISHOP), 0};
         }
 
-        moves = gen_pawn_captures(moves, position, pawn_offset + WEST);
-        moves = gen_pawn_captures(moves, position, pawn_offset + EAST);
+        moves = gen_pawn_captures(moves, position, destination, pawn_offset + WEST);
+        moves = gen_pawn_captures(moves, position, destination, pawn_offset + EAST);
 
         Square en_passant = position.get_en_passant();
         if (en_passant != NO_SQ) {
@@ -96,15 +102,15 @@ static inline ScoredMove* gen_pawn_moves(ScoredMove* moves, const Position& posi
 }
 
 static inline ScoredMove* gen_piece_moves(ScoredMove* moves, const Position& position, const PieceType piece_type,
-                                          const MoveGenType gen_type) {
+                                          const Bitboard& destination, const MoveGenType gen_type) {
     assert(piece_type >= KNIGHT && piece_type <= KING);
 
     Bitboard empty_targets = 0ULL;
     Bitboard enemy_targets = 0ULL;
     if (gen_type & QUIET)
-        empty_targets = ~position.get_occupancy();
+        empty_targets = ~position.get_occupancy() & destination;
     if (gen_type & NOISY)
-        enemy_targets = position.get_occupancy(position.get_adversary());
+        enemy_targets = position.get_occupancy(position.get_adversary()) & destination;
 
     Bitboard pieces = position.get_piece_bb(piece_type, position.get_stm());
     Bitboard occupancy = position.get_occupancy();
@@ -154,13 +160,22 @@ ScoredMove* gen_castling_moves(ScoredMove* moves, const Position& position) {
 }
 
 ScoredMove* gen_moves(ScoredMove* moves, const Position& position, const MoveGenType gen_type) {
-    moves = gen_pawn_moves(moves, position, gen_type);
-    moves = gen_piece_moves(moves, position, KNIGHT, gen_type);
-    moves = gen_piece_moves(moves, position, BISHOP, gen_type);
-    moves = gen_piece_moves(moves, position, ROOK, gen_type);
-    moves = gen_piece_moves(moves, position, QUEEN, gen_type);
-    moves = gen_piece_moves(moves, position, KING, gen_type);
-    if (gen_type & QUIET)
+    Bitboard destination =
+        !position.in_check()
+            ? ALL_BITS
+            : between_squares[position.get_king_placement(position.get_stm())][lsb(position.get_checkers())] |
+                  position.get_checkers();
+
+    if (count_bits(position.get_checkers()) < 2) {
+        moves = gen_pawn_moves(moves, position, destination, gen_type);
+        moves = gen_piece_moves(moves, position, KNIGHT, destination, gen_type);
+        moves = gen_piece_moves(moves, position, BISHOP, destination, gen_type);
+        moves = gen_piece_moves(moves, position, ROOK, destination, gen_type);
+        moves = gen_piece_moves(moves, position, QUEEN, destination, gen_type);
+    }
+    moves = gen_piece_moves(moves, position, KING, ALL_BITS, gen_type);
+
+    if (!position.in_check() && (gen_type & QUIET))
         moves = gen_castling_moves(moves, position);
 
     return moves;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -326,7 +326,7 @@ void Position::make_capture(const Move &move) {
 
     m_curr_state.fifty_move_ply = 0;
     m_curr_state.captured = consult(to);
-    assert(m_curr_state.captured != EMPTY);
+    assert(m_curr_state.captured != EMPTY && get_piece_type(m_curr_state.captured) != KING);
 
     remove_piece<UPDATE>(m_curr_state.captured, to);
     remove_piece<UPDATE>(piece, from);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <cstring>
 #include <iostream>
+#include <string>
 
 #include "attacks.h"
 #include "hash.h"
@@ -759,7 +760,7 @@ void Position::print() const {
             Square sq = get_square(file, rank);
             Piece piece = m_board[sq];
             PieceType piece_type = get_piece_type(piece);
-            char piece_char = ' ';
+            char piece_char = '-';
             if (piece_type == PAWN)
                 piece_char = 'p';
             else if (piece_type == KNIGHT)
@@ -776,7 +777,14 @@ void Position::print() const {
             if (piece <= WHITE_KING) // Piece is white
                 piece_char = toupper(piece_char);
 
-            std::cout << "| " << piece_char << " ";
+            std::string color = "";
+            if (m_curr_state.checkers & (1ULL << sq)) {
+                color = "\033[31m";
+            } else if (m_curr_state.pins & (1ULL << sq)) {
+                color = "\033[34m";
+            }
+
+            std::cout << "| " << color << piece_char << (color != "" ? "\033[0m" : "") << " ";
         }
         std::cout << "| " << rank + 1 << "\n";
     }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -289,7 +289,7 @@ bool Position::make_move(const Move &move) {
     hash_side_key();
 
     if (!move.is_castle()) // If move is a castle, the legality has already been checked by make_castle()
-        legal = !in_check();
+        legal = !is_attacked(get_king_placement(m_stm));
 
     change_side();
     update_pin_and_checkers_bb();

--- a/src/position.h
+++ b/src/position.h
@@ -38,7 +38,7 @@ class Position {
     void make_null_move();
     void unmake_null_move();
 
-    inline bool in_check() const { return is_attacked(get_king_placement(m_stm)); }
+    inline bool in_check() const { return m_curr_state.checkers; }
     bool is_attacked(const Square &sq) const;
     bool is_pseudo_legal(const Move &move) const;
     Bitboard attackers(const Square &sq) const;

--- a/src/position.h
+++ b/src/position.h
@@ -89,6 +89,8 @@ class Position {
     inline Piece consult(const Square &sq) const { return m_board[sq]; }
     inline int get_history_ply() const { return m_history_ply; }
     inline BoardState get_board_state() const { return m_curr_state; };
+    inline Bitboard get_checkers() const { return m_curr_state.checkers; }
+    inline Bitboard get_pins() const { return m_curr_state.pins; }
     inline void reset_history() { m_history_ply = 0; }
 
   private:
@@ -110,6 +112,7 @@ class Position {
     template <bool UPDATE>
     void make_en_passant(const Move &move);
     void update_castling_rights(const Move &move);
+    void update_pin_and_checkers_bb();
 
     bool insufficient_material() const;
     bool repetition() const;

--- a/src/types.h
+++ b/src/types.h
@@ -107,6 +107,7 @@ using TimeType = std::chrono::milliseconds::rep;
 using TimePoint = std::chrono::steady_clock::time_point;
 using Bitboard = uint64_t;
 
+constexpr Bitboard ALL_BITS = -1ULL;
 constexpr int MAX_MOVES_PER_POS = 256;
 constexpr int MAX_SEARCH_DEPTH = 256;
 constexpr int MAX_PLY = MAX_SEARCH_DEPTH + 100 + 5; // Plus 100 because of fifty move rule and plus 5 just to be safe

--- a/src/types.h
+++ b/src/types.h
@@ -148,7 +148,11 @@ struct BoardState {
     int ply_from_null;
     uint8_t castling_rights;
     Square en_passant;
+    Bitboard checkers;
+    Bitboard pins;
     void reset() {
+        checkers = 0;
+        pins = 0;
         captured = EMPTY;
         fifty_move_ply = 0;
         ply_from_null = 0;

--- a/src/utils.h
+++ b/src/utils.h
@@ -11,9 +11,23 @@
 #include <bit>
 #include <cassert>
 #include <cstdint>
+#include <iostream>
 #include <random>
 
 #include "types.h"
+
+inline void print_bb(Bitboard bb) {
+    for (int line = 7; line >= 0; --line) {
+        for (int column = 0; column < 8; ++column) {
+            int sq = line * 8 + column;
+            if (!column)
+                std::cout << "  " << line + 1 << "  ";
+            std::cout << (bb & (1ULL << sq) ? 1 : 0) << " ";
+        }
+        std::cout << "\n";
+    }
+    std::cout << "\n     a b c d e f g h\n\n";
+}
 
 inline void set_bit(Bitboard &bitboard, const Square &sq) { bitboard |= (1ULL << sq); }
 inline void set_bit(Bitboard &bitboard, const int &sq) { bitboard |= (1ULL << sq); }

--- a/src/utils.h
+++ b/src/utils.h
@@ -22,7 +22,7 @@ inline void print_bb(Bitboard bb) {
             int sq = line * 8 + column;
             if (!column)
                 std::cout << "  " << line + 1 << "  ";
-            std::cout << (bb & (1ULL << sq) ? 1 : 0) << " ";
+            std::cout << (bb & (1ULL << sq) ? "\033[32m1\033[0m" : "0") << " ";
         }
         std::cout << "\n";
     }


### PR DESCRIPTION
#### Keep track of pinned pieces and king attackers after every move, using this to improve the pseudo-legal move generator. 

Results of minkePinAndCheckersBB vs minkeMain (10+0.1, NULL, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 0.06 +/- 2.25, nElo: 0.10 +/- 3.95
LOS: 52.02 %, DrawRatio: 47.73 %, PairsRatio: 0.99
Games: 29778, Wins: 6722, Losses: 6717, Draws: 16339, Points: 14891.5 (50.01 %)
Ptnml(0-2): [304, 3604, 7107, 3531, 343], WL/DD Ratio: 0.54
LLR: -2.96 (-100.5%) (-2.94, 2.94) [0.00, 5.00]
SPRT ([0.00, 5.00]) completed - H0 was accepted
