### PR TITLE
Using stm to index capture history

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -65,7 +65,7 @@ void History::update_capture_history_score(const Position &position, const Move 
     Square to = move.to();
     PieceType moved_pt = get_piece_type(position.consult(move.from()));
     PieceType captured_pt = move.is_ep() ? PAWN : get_piece_type(position.consult(to));
-    HistoryType *ptr = &m_capture_history[moved_pt][to][captured_pt];
+    HistoryType *ptr = &m_capture_history[position.get_stm()][moved_pt][to][captured_pt];
     update_score(ptr, bonus);
 }
 

--- a/src/history.h
+++ b/src/history.h
@@ -34,7 +34,7 @@ class History {
         Square to = move.to();
         PieceType moved_pt = get_piece_type(position.consult(move.from()));
         PieceType captured_pt = move.is_ep() ? PAWN : get_piece_type(position.consult(to));
-        return m_capture_history[moved_pt][to][captured_pt];
+        return m_capture_history[position.get_stm()][moved_pt][to][captured_pt];
     }
 
     inline Move consult_killer1(const int &depth) const { return m_killer_moves[0][depth]; }
@@ -63,7 +63,7 @@ class History {
             m_counter_moves[past_move.from_and_to()] = move;
     }
 
-    HistoryType m_capture_history[6][64][5];
+    HistoryType m_capture_history[2][6][64][5];
     HistoryType m_search_history_table[COLOR_NB][64 * 64];
     Move m_counter_moves[64 * 64];
     Move m_killer_moves[2][MAX_SEARCH_DEPTH];


### PR DESCRIPTION
Results of minkeCaptHist vs minkeMain (10+0.1, NULL, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 5.12 +/- 3.71, nElo: 8.82 +/- 6.40
LOS: 99.66 %, DrawRatio: 46.27 %, PairsRatio: 1.12
Games: 11338, Wins: 2698, Losses: 2531, Draws: 6109, Points: 5752.5 (50.74 %)
Ptnml(0-2): [135, 1299, 2623, 1488, 124], WL/DD Ratio: 0.58
LLR: 2.96 (100.6%) (-2.94, 2.94) [0.00, 5.00]
SPRT ([0.00, 5.00]) completed - H1 was accepted