### PR TITLE
Fixing time manager bug on cyclic time controls

### DIFF
--- a/src/time_manager.cpp
+++ b/src/time_manager.cpp
@@ -31,7 +31,7 @@ void TimeManager::reset(CounterType inc, CounterType time, CounterType mtg, Coun
     time = std::min(time - overhead, time / 2); // Decrease the overhead on total time
     time = std::max(time, 1);                   // Ensure time is positive
     inc = std::max(inc, 0);                     // Ensure inc is non negative
-    mtg = (mtg > 0 ? std::max(mtg, 50) : 50);   // Ensure movestogo is at most 50 if positive, else set it to 50
+    mtg = (mtg > 0 ? std::min(mtg, 50) : 50);   // Ensure movestogo is at most 50 if positive, else set it to 50
 
     double base_time = 0.8 * time / static_cast<double>(mtg) + inc;
     m_optimum_time = m_start_time + base_time;


### PR DESCRIPTION
Elo   | 135.49 +- 16.18 (95%)
SPRT  | 40/5.0+0.00s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 816 W: 395 L: 92 D: 329
Penta | [3, 19, 125, 194, 67]
https://eduardomarinho.dev/test/14/

Elo   | 120.26 +- 15.23 (95%)
SPRT  | 40/15.0+0.00s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 844 W: 363 L: 82 D: 399
Penta | [0, 34, 128, 205, 55]
https://eduardomarinho.dev/test/15/