### PR TITLE
Fixing movepicker bug

### DIFF
--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -64,11 +64,10 @@ ScoredMove MovePicker::next_move_scored(const bool &skip_quiets) {
                 else
                     ++m_curr;
             }
-            if (m_qsearch) {
+            if (m_qsearch && skip_quiets) {
                 m_stage = FINISHED;
                 return SCORED_MOVE_NONE;
-            }
-            if (skip_quiets) {
+            } else if (skip_quiets) {
                 m_curr = m_moves;
                 m_stage = PICK_BAD_NOISY;
                 return next_move_scored(skip_quiets); // Work around to avoid the switch fall-through


### PR DESCRIPTION
Elo   | 1.07 +- 2.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.19 (-2.94, 2.94) [0.00, 3.00]
Games | N: 28640 W: 6919 L: 6831 D: 14890
Penta | [392, 3521, 6465, 3491, 451]
https://eduardomarinho.dev/test/22/