### PR TITLE
Fix bug in move picker related to skipping quiet moves

### DIFF
--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -86,7 +86,7 @@ ScoredMove MovePicker::next_move_scored(const bool &skip_quiets) {
             m_stage = PICK_QUIET;
             // Fall-through
         case PICK_QUIET:
-            while (m_curr != m_end) {
+            while (m_curr != m_end && !skip_quiets) {
                 sort_next_move();
                 if (m_curr->move != m_ttmove)
                     return *m_curr++;


### PR DESCRIPTION
```
Elo   | 41.21 +- 10.52 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=64MB
LLR   | 2.26 (-2.89, 2.25) [0.00, 3.00]
Games | N: 1330 W: 414 L: 257 D: 659
Penta | [7, 100, 309, 227, 22]
https://eduardomarinho.dev/test/266/
```
Bench: 1467074