### PR TITLE
Use is_legal in negamax to validate move instead of relying on make for legality checks

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -317,8 +317,6 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             position.unmake_move<true>(move);
             continue;
         }
-        PieceMove curr_pmove = {move, position.consult(move.to())}; // move.to() because move has already been made
-        node.curr_pmove = curr_pmove;
 
         if (!root && best_score >= -MATE_FOUND && !skip_quiets) {
             // Late Move Pruning
@@ -340,7 +338,6 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             td.nodes[td.height].excluded_move = ttmove;
             ScoreType singular_score = negamax(singular_beta - 1, singular_beta, singular_depth, cutnode, td);
             td.nodes[td.height].excluded_move = MOVE_NONE;
-            node.curr_pmove = curr_pmove; // reassign this, since singular search messed it up
 
             if (singular_score < singular_beta) {
                 extension = 1;
@@ -354,14 +351,15 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
             position.make_move<true>(ttmove);
         }
+        node.curr_pmove = {move, position.consult(move.to())}; // move.to() because move has already been made
         td.tt.prefetch(position.get_hash());
         int new_depth = depth + extension;
 
         // Add move to tried list
         if (move.is_quiet())
-            quiets_tried.push(curr_pmove);
+            quiets_tried.push(node.curr_pmove);
         else
-            tacticals_tried.push(curr_pmove);
+            tacticals_tried.push(node.curr_pmove);
 
         ++td.height;
         ++moves_searched;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -313,8 +313,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
     while ((move = move_picker.next_move(skip_quiets)) != MOVE_NONE) {
         if (move == td.nodes[td.height].excluded_move) // Skip excluded moves
             continue;
-        if (!position.make_move<true>(move)) { // Avoid illegal moves
-            position.unmake_move<true>(move);
+        if (!position.is_legal(move)) { // Avoid illegal moves
             continue;
         }
 
@@ -332,7 +331,6 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             ScoreType singular_beta = ttscore - depth;
             ScoreType singular_depth = (depth - 1) / 2;
 
-            position.unmake_move<true>(ttmove);
             td.tt.prefetch(position.get_hash());
 
             td.nodes[td.height].excluded_move = ttmove;
@@ -348,10 +346,11 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                 // } else if (ttscore <= alpha && ttscore >= beta) {
                 //     extension = -1;
             }
-
-            position.make_move<true>(ttmove);
         }
+
+        position.make_move<true>(move);
         node.curr_pmove = {move, position.consult(move.to())}; // move.to() because move has already been made
+
         td.tt.prefetch(position.get_hash());
         int new_depth = depth + extension;
 


### PR DESCRIPTION
```
Elo   | -0.00 +- 4.30 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=64MB
LLR   | -0.25 (-2.89, 2.25) [0.00, 3.00]
Games | N: 6800 W: 1586 L: 1586 D: 3628
Penta | [38, 775, 1767, 789, 31]
```
https://eduardomarinho.dev/test/284/
Bench: 1467074

This should have been non-regressive.