### PR TITLE
Tuned lmr

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -51,9 +51,7 @@ void init_all() {
 void init_search_params() {
     for (int depth = 1; depth < 64; ++depth) {
         for (int move_counter = 1; move_counter < 64; ++move_counter) {
-            LMR_TABLE[depth][move_counter] =
-                (lmr_base() / 100.0) + std::log(depth) * std::log(move_counter) / (lmr_divisor() / 100.0);
-            assert(LMR_TABLE[depth][move_counter] > 0);
+            LMR_TABLE[depth][move_counter] = lmr_base() + lmr_scale() * std::log(depth) * std::log(move_counter);
         }
     }
     LMR_TABLE[0][0] = 0;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -369,31 +369,32 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
         if (moves_searched == 1) {
             score = -negamax(-beta, -alpha, new_depth - 1, false, td);
         } else {
-            int reduction = 1;
+            int scaled_reduction = 1024;
             // Late Move Reduction
             if (moves_searched > 1 && depth > 2 && move.is_quiet()) {
-                reduction = LMR_TABLE[std::min(depth, 63)][std::min(moves_searched, 63)];
+                scaled_reduction = LMR_TABLE[std::min(depth, 63)][std::min(moves_searched, 63)];
 
-                if (position.get_checkers()) // Reduce less when in check
-                    reduction -= 1;
+                if (position.get_checkers()) // Reduce less for moves that give check
+                    scaled_reduction -= lmr_gives_check_delta();
 
-                reduction += !improving; // Reduce more if not improving
-                reduction += cutnode;    // Reduce cutnodes more
+                scaled_reduction += !improving * lmr_non_improving_delta(); // Reduce more if not improving
+                scaled_reduction += cutnode * lmr_cutnode_delta();          // Reduce cutnodes more
 
                 // Reduce less if move is killer or counter
-                reduction -= td.search_history.is_killer(move, td.height - 1);
+                scaled_reduction -= td.search_history.is_killer(move, td.height - 1) * lmr_killer_delta();
                 if (td.height >= 2)
-                    reduction -= td.search_history.is_counter(move, td.nodes[td.height - 2].curr_pmove.move);
+                    scaled_reduction -= td.search_history.is_counter(move, td.nodes[td.height - 2].curr_pmove.move) *
+                                        lmr_counter_delta();
 
                 // Reduce less if this move is or was a principal variation
-                reduction -= ttpv;
+                scaled_reduction -= ttpv * lmr_ttpv_delta();
             } else {
                 // reduce noisy
             }
-            const int lmr_depth = std::min(std::max(new_depth - reduction, 1), new_depth - 1);
+            const int lmr_depth = std::min(std::max(new_depth - scaled_reduction / 1024, 1), new_depth - 1);
             score = -negamax(-alpha - 1, -alpha, lmr_depth, true, td);
 
-            if (score > alpha && reduction > 1) {
+            if (score > alpha && scaled_reduction > 1024) {
                 new_depth += score > best_score + 35;
                 new_depth -= score < best_score + new_depth;
 

--- a/src/tune.h
+++ b/src/tune.h
@@ -136,8 +136,14 @@ TUNABLE_PARAM(rfp_margin, 105, 50, 150, 5, 0.002)
 TUNABLE_PARAM(rfp_max_depth, 10, 5, 15, 0.5, 0.002)
 
 // Late Move Reductions
-TUNABLE_PARAM(lmr_base, 108, 50, 150, 5, 0.002)
-TUNABLE_PARAM(lmr_divisor, 200, 150, 350, 10, 0.002)
+TUNABLE_PARAM(lmr_base, 1106, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_scale, 512, 256, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_gives_check_delta, 1024, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_non_improving_delta, 1024, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_cutnode_delta, 1024, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_killer_delta, 1024, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_counter_delta, 1024, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_ttpv_delta, 1024, 512, 2048, 128, 0.002)
 
 // Late Moves Pruning
 TUNABLE_PARAM(lmp_base, 125, 100, 200, 5, 0.002)

--- a/src/tune.h
+++ b/src/tune.h
@@ -136,14 +136,14 @@ TUNABLE_PARAM(rfp_margin, 105, 50, 150, 5, 0.002)
 TUNABLE_PARAM(rfp_max_depth, 10, 5, 15, 0.5, 0.002)
 
 // Late Move Reductions
-TUNABLE_PARAM(lmr_base, 1106, 512, 2048, 128, 0.002)
-TUNABLE_PARAM(lmr_scale, 512, 256, 2048, 128, 0.002)
-TUNABLE_PARAM(lmr_gives_check_delta, 1024, 512, 2048, 128, 0.002)
-TUNABLE_PARAM(lmr_non_improving_delta, 1024, 512, 2048, 128, 0.002)
-TUNABLE_PARAM(lmr_cutnode_delta, 1024, 512, 2048, 128, 0.002)
-TUNABLE_PARAM(lmr_killer_delta, 1024, 512, 2048, 128, 0.002)
-TUNABLE_PARAM(lmr_counter_delta, 1024, 512, 2048, 128, 0.002)
-TUNABLE_PARAM(lmr_ttpv_delta, 1024, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_base, 1087, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_scale, 584, 256, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_gives_check_delta, 1012, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_non_improving_delta, 972, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_cutnode_delta, 1001, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_killer_delta, 1047, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_counter_delta, 1011, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_ttpv_delta, 971, 512, 2048, 128, 0.002)
 
 // Late Moves Pruning
 TUNABLE_PARAM(lmp_base, 125, 100, 200, 5, 0.002)


### PR DESCRIPTION
STC
```
Elo   | 1.94 +- 1.76 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=64MB
LLR   | 2.28 (-2.89, 2.25) [0.00, 3.00]
Games | N: 43240 W: 10218 L: 9976 D: 23046
Penta | [255, 5089, 10702, 5307, 267]
```
https://eduardomarinho.dev/test/311/

LTC
```
Elo   | 0.04 +- 3.58 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.34 (-2.89, 2.25) [0.00, 3.00]
Games | N: 9654 W: 2144 L: 2143 D: 5367
Penta | [29, 1174, 2416, 1183, 25]
```
https://eduardomarinho.dev/test/312/