### PR TITLE
Simplify how NMP reduction is calculated

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -253,9 +253,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
         // Null move pruning
         if (!position.last_was_null() && depth >= nmp_min_depth() && eval >= beta && position.has_non_pawns()) {
-            // TODO check for advanced tweaks
-            const int reduction =
-                nmp_base_reduction() + depth / nmp_depth_reduction_divisor() + std::clamp((eval - beta) / 300, -1, 3);
+            const int reduction = nmp_base_reduction() + depth / nmp_depth_reduction_divisor();
 
             position.make_null_move();
             td.tt.prefetch(position.get_hash());


### PR DESCRIPTION
```
Elo   | 0.28 +- 2.25 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=64MB
LLR   | -0.65 (-2.89, 2.25) [0.00, 3.00]
Games | N: 26842 W: 6199 L: 6177 D: 14466
Penta | [155, 3262, 6590, 3234, 180]
```
https://eduardomarinho.dev/test/307/
