### PR TITLE
Double extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -342,11 +342,10 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             if (singular_score < singular_beta) {
                 extension = 1;
 
-                // TODO double extension
+                if (!pv_node && singular_score < beta - double_extension_margin())
+                    extension = 2;
             } else if (singular_score >= beta) { // Multi-Cut
                 return singular_score;
-                // } else if (ttscore <= alpha && ttscore >= beta) {
-                //     extension = -1;
             }
         }
 

--- a/src/tune.h
+++ b/src/tune.h
@@ -151,6 +151,7 @@ TUNABLE_PARAM(lmp_scale, 35, 20, 120, 5, 0.002)
 
 // Singular Extension
 TUNABLE_PARAM(singular_extension_min_depth, 7, 4, 10, 0.5, 0.002)
+TUNABLE_PARAM(double_extension_margin, 10, -20, 40, 3, 0.002)
 
 // Interval Iterative Reduction
 FIXED_PARAM(iir_min_depth, 3, 3, 8, 0.5, 0.002)


### PR DESCRIPTION
```
Elo   | 11.84 +- 5.46 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=64MB
LLR   | 2.27 (-2.89, 2.25) [0.00, 3.00]
Games | N: 4434 W: 1071 L: 920 D: 2443
Penta | [21, 466, 1101, 599, 30]
```
https://eduardomarinho.dev/test/325/

Bench: 1730622