### PR TITLE
Perform double negative ext when singular search failed and cutnode

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -346,6 +346,8 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                     extension = 2;
             } else if (singular_score >= beta) { // Multi-Cut
                 return singular_score;
+            } else if (cutnode) {
+                extension = -2;
             }
         }
 


### PR DESCRIPTION
```
Elo   | 5.68 +- 3.64 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=64MB
LLR   | 2.26 (-2.89, 2.25) [0.00, 3.00]
Games | N: 9914 W: 2402 L: 2240 D: 5272
Penta | [44, 1136, 2449, 1270, 58]
```
https://eduardomarinho.dev/test/328/

Bench: 1775130