### PR TITLE
Don't ignore TT hits when updating TT entries on SE

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -231,7 +231,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
     } else {
         raw_eval = position.eval();
         eval = node.static_eval = adjust_eval(position, raw_eval);
-        td.tt.store(position.get_hash(), 0, MOVE_NONE, SCORE_NONE, raw_eval, BOUND_EMPTY, ttpv, td.tt.age(), tthit);
+        td.tt.store(position.get_hash(), 0, MOVE_NONE, SCORE_NONE, raw_eval, BOUND_EMPTY, ttpv, td.tt.age());
     }
 
     // Clean killer moves for the next ply
@@ -295,8 +295,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                 position.unmake_move<true>(move);
 
                 if (pc_score >= pc_beta) {
-                    td.tt.store(position.get_hash(), depth - 3, move, pc_score, raw_eval, LOWER, ttpv, td.tt.age(),
-                                tthit);
+                    td.tt.store(position.get_hash(), depth - 3, move, pc_score, raw_eval, LOWER, ttpv, td.tt.age());
                     return pc_score;
                 }
             }
@@ -438,7 +437,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
     if (!stop_search(td)) { // Save on TT if search was completed
         BoundType bound = best_score >= beta ? LOWER : (alpha != old_alpha ? EXACT : UPPER);
-        td.tt.store(position.get_hash(), depth, best_move, best_score, raw_eval, bound, ttpv, td.tt.age(), tthit);
+        td.tt.store(position.get_hash(), depth, best_move, best_score, raw_eval, bound, ttpv, td.tt.age());
         td.best_move = best_move;
     }
 
@@ -486,7 +485,7 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
     } else {
         raw_eval = position.eval();
         best_score = static_eval = node.static_eval = adjust_eval(position, raw_eval);
-        td.tt.store(position.get_hash(), 0, MOVE_NONE, SCORE_NONE, raw_eval, BOUND_EMPTY, ttpv, td.tt.age(), tthit);
+        td.tt.store(position.get_hash(), 0, MOVE_NONE, SCORE_NONE, raw_eval, BOUND_EMPTY, ttpv, td.tt.age());
     }
 
     // Stand-pat
@@ -538,7 +537,7 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
     }
 
     BoundType bound = best_score >= beta ? LOWER : UPPER;
-    td.tt.store(position.get_hash(), 0, best_move, best_score, raw_eval, bound, ttpv, td.tt.age(), tthit);
+    td.tt.store(position.get_hash(), 0, best_move, best_score, raw_eval, bound, ttpv, td.tt.age());
 
     return best_score;
 }

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -70,14 +70,17 @@ bool TranspositionTable::probe(const Position &position, TTEntry &tte) {
 
 void TranspositionTable::store(const HashType &hash, const IndexType &depth, const Move &best_move,
                                const ScoreType &score, const ScoreType &eval, const BoundType &bound, const bool was_pv,
-                               const IndexType age, const bool &tthit) {
+                               const IndexType age) {
     size_t table_index = table_index_from_hash(hash);
     KeyType target_key = key_from_hash(hash);
     TTBucket *bucket = &m_table[table_index];
     TTEntry *replace = &bucket->entry[0];
+
+    bool tthit = false;
     for (IndexType index = 0; index < BUCKET_SIZE; ++index) {
         if (bucket->entry[index].key() == target_key) {
             replace = &bucket->entry[index];
+            tthit = true;
             break;
         }
         if (replace->depth() > bucket->entry[index].depth())

--- a/src/tt.h
+++ b/src/tt.h
@@ -80,8 +80,7 @@ class TranspositionTable {
 
     bool probe(const Position &position, TTEntry &found);
     void store(const HashType &hash, const IndexType &depth, const Move &best_move, const ScoreType &score,
-               const ScoreType &eval, const BoundType &bound, const bool was_pv, const IndexType age,
-               const bool &tthit);
+               const ScoreType &eval, const BoundType &bound, const bool was_pv, const IndexType age);
     void update_age() { m_age = (m_age + 1) & AGE_MASK; }
     IndexType age() { return m_age; }
     void prefetch(const HashType &key);


### PR DESCRIPTION
```
Elo   | 6.49 +- 3.93 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=256MB
LLR   | 2.28 (-2.89, 2.25) [0.00, 3.00]
Games | N: 8616 W: 2094 L: 1933 D: 4589
Penta | [40, 971, 2148, 1086, 63]
```
https://eduardomarinho.dev/test/340/
