### PR TITLE
Tuned params from 'tune3'

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -58,7 +58,7 @@ void init_search_params() {
 
     for (int depth = 0; depth < LMP_DEPTH; ++depth) {
         LMP_TABLE[0][depth] = (lmp_base() / 100.0) + (lmp_scale() / 100.0) * depth * depth;
-        LMP_TABLE[1][depth] = 2 * (lmp_base() / 100.0) + 2 * (lmp_scale() / 100.0) * depth * depth; // Improving
+        LMP_TABLE[1][depth] = (lmp_improving_base() / 100.0) + (lmp_improving_scale() / 100.0) * depth * depth;
     }
 }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -328,7 +328,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
         // Extensions
         int extension = 0;
-        if (!root && depth > singular_extension_min_depth() && move == ttmove && ttdepth > depth - 4 &&
+        if (!root && depth >= singular_extension_min_depth() && move == ttmove && ttdepth > depth - 4 &&
             move != td.nodes[td.height].excluded_move && ttbound == LOWER) {
             ScoreType singular_beta = ttscore - depth * singular_extension_depth_factor() / 16;
             ScoreType singular_depth = (depth - 1) / 2;
@@ -373,7 +373,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
         } else {
             int scaled_reduction = 1024;
             // Late Move Reduction
-            if (moves_searched > 1 && depth > 2 && move.is_quiet()) {
+            if (moves_searched > 1 && depth >= 3 && move.is_quiet()) {
                 scaled_reduction = LMR_TABLE[std::min(depth, 63)][std::min(moves_searched, 63)];
 
                 if (position.get_checkers()) // Reduce less for moves that give check

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -211,8 +211,8 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
     }
 
     // Internal Iterative Reductions
-    if ((!tthit || ttdepth + 4 < depth) && depth >= iir_min_depth()) {
-        depth -= iir_depth_reduction();
+    if ((!tthit || ttdepth + 4 < depth) && depth >= 3) {
+        depth -= 1;
     }
 
     bool in_check = position.in_check();
@@ -256,7 +256,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
         // Null move pruning
         if (!position.last_was_null() && depth >= nmp_min_depth() && eval >= beta && position.has_non_pawns()) {
-            const int reduction = nmp_base_reduction() + depth / nmp_depth_reduction_divisor();
+            const int reduction = (nmp_base_reduction() + depth * nmp_depth_factor()) / 64;
 
             position.make_null_move();
             td.tt.prefetch(position.get_hash());
@@ -330,7 +330,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
         int extension = 0;
         if (!root && depth > singular_extension_min_depth() && move == ttmove && ttdepth > depth - 4 &&
             move != td.nodes[td.height].excluded_move && ttbound == LOWER) {
-            ScoreType singular_beta = ttscore - depth;
+            ScoreType singular_beta = ttscore - depth * singular_extension_depth_factor() / 16;
             ScoreType singular_depth = (depth - 1) / 2;
 
             td.tt.prefetch(position.get_hash());

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -346,6 +346,8 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                     extension = 2;
             } else if (singular_score >= beta) { // Multi-Cut
                 return singular_score;
+            } else if (cutnode) {
+                extension = -2;
             }
         }
 

--- a/src/tune.h
+++ b/src/tune.h
@@ -123,17 +123,17 @@ class TunableParamList {
 
 // Aspiration Windows
 FIXED_PARAM(aw_min_depth, 3, 1, 10, 0.5, 0.002)
-TUNABLE_PARAM(aw_first_window, 11, 5, 200, 10, 0.002)
+TUNABLE_PARAM(aw_first_window, 11, 5, 25, 2, 0.002)
 TUNABLE_PARAM(aw_widening_factor, 49, 1, 100, 5, 0.002)
 
 // Null move pruning
-TUNABLE_PARAM(nmp_base_reduction, 4, 1, 5, 0.5, 0.002)
-TUNABLE_PARAM(nmp_depth_reduction_divisor, 3, 2, 8, 0.5, 0.002)
-TUNABLE_PARAM(nmp_min_depth, 2, 2, 8, 0.5, 0.002)
+TUNABLE_PARAM(nmp_base_reduction, 256, 128, 384, 15, 0.002)
+TUNABLE_PARAM(nmp_depth_factor, 21, 16, 63, 0.5, 0.002)
+FIXED_PARAM(nmp_min_depth, 2, 2, 8, 0.5, 0.002)
 
 // Reverse Futility Pruning
-TUNABLE_PARAM(rfp_margin, 105, 50, 150, 5, 0.002)
-TUNABLE_PARAM(rfp_max_depth, 10, 5, 15, 0.5, 0.002)
+TUNABLE_PARAM(rfp_margin, 105, 50, 150, 10, 0.002)
+FIXED_PARAM(rfp_max_depth, 10, 5, 15, 0.5, 0.002)
 
 // Late Move Reductions
 TUNABLE_PARAM(lmr_base, 1087, 512, 2048, 128, 0.002)
@@ -148,13 +148,12 @@ TUNABLE_PARAM(lmr_ttpv_delta, 971, 512, 2048, 128, 0.002)
 // Late Moves Pruning
 TUNABLE_PARAM(lmp_base, 125, 100, 200, 5, 0.002)
 TUNABLE_PARAM(lmp_scale, 35, 20, 120, 5, 0.002)
+TUNABLE_PARAM(lmp_improving_base, 250, 200, 400, 5, 0.002)
+TUNABLE_PARAM(lmp_improving_scale, 70, 40, 240, 5, 0.002)
 
 // Singular Extension
-TUNABLE_PARAM(singular_extension_min_depth, 7, 4, 10, 0.5, 0.002)
-
-// Interval Iterative Reduction
-FIXED_PARAM(iir_min_depth, 3, 3, 8, 0.5, 0.002)
-FIXED_PARAM(iir_depth_reduction, 1, 1, 4, 0.5, 0.002)
+FIXED_PARAM(singular_extension_min_depth, 8, 4, 10, 0.5, 0.002)
+TUNABLE_PARAM(singular_extension_depth_factor, 16, 10, 20, 1, 0.002)
 
 // Razoring
 TUNABLE_PARAM(razoring_max_depth, 5, 2, 6, 0.5, 0.002)
@@ -199,11 +198,11 @@ TUNABLE_PARAM(tm_min_scale, 48, 10, 100, 7, 0.002)
 TUNABLE_PARAM(tm_max_scale, 166, 100, 250, 7, 0.002)
 
 // Material scale
-TUNABLE_PARAM(pawn_scaling_factor, 100, 64, 128, 5, 0.002)
-TUNABLE_PARAM(knight_scaling_factor, 300, 128, 512, 20, 0.002)
-TUNABLE_PARAM(bishop_scaling_factor, 330, 128, 512, 20, 0.002)
-TUNABLE_PARAM(rook_scaling_factor, 512, 384, 768, 20, 0.002)
-TUNABLE_PARAM(queen_scaling_factor, 1024, 768, 1280, 20, 0.002)
-TUNABLE_PARAM(material_scaling_base, 25000, 16384, 32768, 800, 0.002)
+TUNABLE_PARAM(pawn_scaling_factor, 100, 20, 160, 5, 0.002)
+TUNABLE_PARAM(knight_scaling_factor, 300, 200, 600, 20, 0.002)
+TUNABLE_PARAM(bishop_scaling_factor, 330, 200, 600, 20, 0.002)
+TUNABLE_PARAM(rook_scaling_factor, 512, 400, 800, 20, 0.002)
+TUNABLE_PARAM(queen_scaling_factor, 1024, 800, 1400, 30, 0.002)
+TUNABLE_PARAM(material_scaling_base, 25000, 20000, 40000, 1000, 0.002)
 
 #endif // #ifndef TUNE_H

--- a/src/tune.h
+++ b/src/tune.h
@@ -127,29 +127,29 @@ TUNABLE_PARAM(aw_first_window, 11, 5, 25, 2, 0.002)
 TUNABLE_PARAM(aw_widening_factor, 49, 1, 100, 5, 0.002)
 
 // Null move pruning
-TUNABLE_PARAM(nmp_base_reduction, 256, 128, 384, 15, 0.002)
+TUNABLE_PARAM(nmp_base_reduction, 260, 128, 384, 15, 0.002)
 TUNABLE_PARAM(nmp_depth_factor, 21, 16, 63, 0.5, 0.002)
 FIXED_PARAM(nmp_min_depth, 2, 2, 8, 0.5, 0.002)
 
 // Reverse Futility Pruning
-TUNABLE_PARAM(rfp_margin, 105, 50, 150, 10, 0.002)
+TUNABLE_PARAM(rfp_margin, 104, 50, 150, 10, 0.002)
 FIXED_PARAM(rfp_max_depth, 10, 5, 15, 0.5, 0.002)
 
 // Late Move Reductions
-TUNABLE_PARAM(lmr_base, 1087, 512, 2048, 128, 0.002)
-TUNABLE_PARAM(lmr_scale, 584, 256, 2048, 128, 0.002)
-TUNABLE_PARAM(lmr_gives_check_delta, 1012, 512, 2048, 128, 0.002)
-TUNABLE_PARAM(lmr_non_improving_delta, 972, 512, 2048, 128, 0.002)
-TUNABLE_PARAM(lmr_cutnode_delta, 1001, 512, 2048, 128, 0.002)
-TUNABLE_PARAM(lmr_killer_delta, 1047, 512, 2048, 128, 0.002)
-TUNABLE_PARAM(lmr_counter_delta, 1011, 512, 2048, 128, 0.002)
-TUNABLE_PARAM(lmr_ttpv_delta, 971, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_base, 1107, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_scale, 688, 256, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_gives_check_delta, 1066, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_non_improving_delta, 925, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_cutnode_delta, 959, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_killer_delta, 1089, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_counter_delta, 1009, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_ttpv_delta, 987, 512, 2048, 128, 0.002)
 
 // Late Moves Pruning
-TUNABLE_PARAM(lmp_base, 125, 100, 200, 5, 0.002)
+TUNABLE_PARAM(lmp_base, 128, 100, 200, 5, 0.002)
 TUNABLE_PARAM(lmp_scale, 35, 20, 120, 5, 0.002)
-TUNABLE_PARAM(lmp_improving_base, 250, 200, 400, 5, 0.002)
-TUNABLE_PARAM(lmp_improving_scale, 70, 40, 240, 5, 0.002)
+TUNABLE_PARAM(lmp_improving_base, 252, 200, 400, 5, 0.002)
+TUNABLE_PARAM(lmp_improving_scale, 73, 40, 240, 5, 0.002)
 
 // Singular Extension
 FIXED_PARAM(singular_extension_min_depth, 8, 4, 10, 0.5, 0.002)
@@ -158,52 +158,52 @@ TUNABLE_PARAM(double_extension_margin, 10, -20, 40, 3, 0.002)
 
 // Razoring
 TUNABLE_PARAM(razoring_max_depth, 5, 2, 6, 0.5, 0.002)
-TUNABLE_PARAM(razoring_mult, 244, 150, 300, 7.5, 0.002)
+TUNABLE_PARAM(razoring_mult, 242, 150, 300, 7.5, 0.002)
 
 // Futility Pruning
-TUNABLE_PARAM(qs_futility_margin, 213, 0, 500, 25, 0.002)
+TUNABLE_PARAM(qs_futility_margin, 208, 0, 500, 25, 0.002)
 
 // Prob Cut
-TUNABLE_PARAM(probcut_margin, 299, 100, 400, 15, 0.002)
+TUNABLE_PARAM(probcut_margin, 296, 100, 400, 15, 0.002)
 FIXED_PARAM(probcut_min_depth, 5, 4, 8, 0.5, 0.002)
 
 // History Formulas Parameters
-TUNABLE_PARAM(hist_bonus_mult, 219, 1, 1024, 50, 0.002)
-TUNABLE_PARAM(hist_bonus_offset, 367, -512, 512, 50, 0.002)
-TUNABLE_PARAM(hist_bonus_max, 2269, 1500, 3500, 100, 0.002)
+TUNABLE_PARAM(hist_bonus_mult, 200, 1, 1024, 50, 0.002)
+TUNABLE_PARAM(hist_bonus_offset, 393, -512, 512, 50, 0.002)
+TUNABLE_PARAM(hist_bonus_max, 2311, 1500, 3500, 100, 0.002)
 
-TUNABLE_PARAM(hist_penalty_mult, -57, -1024, -1, 50, 0.002)
-TUNABLE_PARAM(hist_penalty_offset, -21, -512, 512, 50, 0.002)
-TUNABLE_PARAM(hist_penalty_max, -1059, -3500, -500, 150, 0.002)
+TUNABLE_PARAM(hist_penalty_mult, -37, -1024, -1, 50, 0.002)
+TUNABLE_PARAM(hist_penalty_offset, -24, -512, 512, 50, 0.002)
+TUNABLE_PARAM(hist_penalty_max, -1058, -3500, -500, 150, 0.002)
 
-TUNABLE_PARAM(cont_bonus_mult, 153, 1, 1024, 50, 0.002)
-TUNABLE_PARAM(cont_bonus_offset, 387, -512, 512, 50, 0.002)
-TUNABLE_PARAM(cont_bonus_max, 2381, 1500, 3500, 100, 0.002)
+TUNABLE_PARAM(cont_bonus_mult, 168, 1, 1024, 50, 0.002)
+TUNABLE_PARAM(cont_bonus_offset, 430, -512, 512, 50, 0.002)
+TUNABLE_PARAM(cont_bonus_max, 2408, 1500, 3500, 100, 0.002)
 
-TUNABLE_PARAM(cont_penalty_mult, -103, -1024, -1, 50, 0.002)
-TUNABLE_PARAM(cont_penalty_offset, -61, -512, 512, 50, 0.002)
-TUNABLE_PARAM(cont_penalty_max, -1154, -3500, -500, 150, 0.002)
+TUNABLE_PARAM(cont_penalty_mult, -63, -1024, -1, 50, 0.002)
+TUNABLE_PARAM(cont_penalty_offset, -68, -512, 512, 50, 0.002)
+TUNABLE_PARAM(cont_penalty_max, -1145, -3500, -500, 150, 0.002)
 
-TUNABLE_PARAM(capt_hist_bonus_mult, 217, 1, 1024, 50, 0.002)
-TUNABLE_PARAM(capt_hist_bonus_offset, -55, -512, 512, 50, 0.002)
-TUNABLE_PARAM(capt_hist_bonus_max, 1415, 500, 3500, 150, 0.002)
+TUNABLE_PARAM(capt_hist_bonus_mult, 213, 1, 1024, 50, 0.002)
+TUNABLE_PARAM(capt_hist_bonus_offset, -44, -512, 512, 50, 0.002)
+TUNABLE_PARAM(capt_hist_bonus_max, 1395, 500, 3500, 150, 0.002)
 
-TUNABLE_PARAM(capt_hist_penalty_mult, -375, -1024, -1, 50, 0.002)
-TUNABLE_PARAM(capt_hist_penalty_offset, 20, -512, 512, 50, 0.002)
-TUNABLE_PARAM(capt_hist_penalty_max, -1210, -3500, -500, 150, 0.002)
+TUNABLE_PARAM(capt_hist_penalty_mult, -380, -1024, -1, 50, 0.002)
+TUNABLE_PARAM(capt_hist_penalty_offset, 44, -512, 512, 50, 0.002)
+TUNABLE_PARAM(capt_hist_penalty_max, -1176, -3500, -500, 150, 0.002)
 
 // Time Manager
-TUNABLE_PARAM(node_tm_base, 193, 150, 300, 7, 0.002)
-TUNABLE_PARAM(node_tm_scale, 164, 100, 250, 7, 0.002)
-TUNABLE_PARAM(tm_min_scale, 48, 10, 100, 7, 0.002)
-TUNABLE_PARAM(tm_max_scale, 166, 100, 250, 7, 0.002)
+TUNABLE_PARAM(node_tm_base, 191, 150, 300, 7, 0.002)
+TUNABLE_PARAM(node_tm_scale, 162, 100, 250, 7, 0.002)
+TUNABLE_PARAM(tm_min_scale, 46, 10, 100, 7, 0.002)
+TUNABLE_PARAM(tm_max_scale, 167, 100, 250, 7, 0.002)
 
 // Material scale
 TUNABLE_PARAM(pawn_scaling_factor, 100, 20, 160, 5, 0.002)
-TUNABLE_PARAM(knight_scaling_factor, 300, 200, 600, 20, 0.002)
-TUNABLE_PARAM(bishop_scaling_factor, 330, 200, 600, 20, 0.002)
-TUNABLE_PARAM(rook_scaling_factor, 512, 400, 800, 20, 0.002)
-TUNABLE_PARAM(queen_scaling_factor, 1024, 800, 1400, 30, 0.002)
-TUNABLE_PARAM(material_scaling_base, 25000, 20000, 40000, 1000, 0.002)
+TUNABLE_PARAM(knight_scaling_factor, 301, 200, 600, 20, 0.002)
+TUNABLE_PARAM(bishop_scaling_factor, 327, 200, 600, 20, 0.002)
+TUNABLE_PARAM(rook_scaling_factor, 517, 400, 800, 20, 0.002)
+TUNABLE_PARAM(queen_scaling_factor, 1008, 800, 1400, 30, 0.002)
+TUNABLE_PARAM(material_scaling_base, 25337, 20000, 40000, 1000, 0.002)
 
 #endif // #ifndef TUNE_H


### PR DESCRIPTION
```
Elo   | 2.32 +- 2.63 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=64MB
LLR   | 1.35 (-2.89, 2.25) [0.00, 3.00]
Games | N: 19146 W: 4537 L: 4409 D: 10200
Penta | [100, 2274, 4700, 2396, 103]
```
https://eduardomarinho.dev/test/335/
```
Elo   | 0.75 +- 4.16 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.01 (-2.89, 2.25) [0.00, 3.00]
Games | N: 6964 W: 1542 L: 1527 D: 3895
Penta | [20, 817, 1793, 832, 20]
```
https://eduardomarinho.dev/test/336/