### PR TITLE
Improve noisy move scoring v2

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -43,7 +43,9 @@ class History {
     inline HistoryType get_capture_history(const Position &position, const Move &move) {
         Square to = move.to();
         PieceType moved_pt = get_piece_type(position.consult(move.from()));
-        PieceType captured_pt = move.is_ep() ? PAWN : get_piece_type(position.consult(to));
+        PieceType captured_pt = get_piece_type(position.consult(to));
+        if (move.is_ep() || move.is_promotion())
+            captured_pt = PAWN;
         return m_capture_history[position.get_stm()][moved_pt][to][captured_pt];
     }
 

--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -65,14 +65,13 @@ ScoredMove MovePicker::next_move_scored(const bool &skip_quiets) {
             // Fall-through
         case GEN_NOISY:
             m_end = gen_moves(m_curr, m_td->position, NOISY);
-            score_moves();
+            score_noisy_moves();
             m_stage = PICK_GOOD_NOISY;
             // Fall-through
         case PICK_GOOD_NOISY:
             while (m_curr != m_end) {
                 sort_next_move();
-                if (!SEE(m_td->position, m_curr->move, m_threshold) ||
-                    m_curr->score == NON_QUEEN_PROMOTION_SCORE) // Bad noisy
+                if (!SEE(m_td->position, m_curr->move, m_threshold)) // Bad noisy
                     *m_end_bad++ = *m_curr++;
                 else if (m_curr->move != m_ttmove)
                     return *m_curr++;
@@ -93,7 +92,7 @@ ScoredMove MovePicker::next_move_scored(const bool &skip_quiets) {
             // Fall-through
         case GEN_QUIET:
             m_end = gen_moves(m_curr, m_td->position, QUIET);
-            score_moves();
+            score_quiet_moves();
             m_stage = PICK_QUIET;
             // Fall-through
         case PICK_QUIET:
@@ -133,38 +132,34 @@ void MovePicker::sort_next_move() {
     std::swap(*best_move, *m_curr);
 }
 
-void MovePicker::score_moves() {
+void MovePicker::score_quiet_moves() {
     for (ScoredMove *runner = m_curr; runner != m_end; ++runner) {
-        switch (runner->move.type()) {
-            case CASTLING:
-                // Fall-through
-            case REGULAR:
-                if (runner->move == m_killer1)
-                    runner->score = KILLER_1_SCORE;
-                else if (runner->move == m_killer2)
-                    runner->score = KILLER_2_SCORE;
-                else if (runner->move == m_counter)
-                    runner->score = COUNTER_SCORE;
-                else
-                    runner->score = m_td->search_history.get_history(*m_td, runner->move);
-                break;
-            case CAPTURE:
-                runner->score = CAPTURE_SCORE + 20 * SEE_VALUES[m_td->position.consult(runner->move.to())] +
-                                m_td->search_history.get_capture_history(m_td->position, runner->move);
-                break;
-            case EP:
-                runner->score = CAPTURE_SCORE + 20 * SEE_VALUES[PAWN] +
-                                m_td->search_history.get_capture_history(m_td->position, runner->move);
-                break;
-            case PAWN_PROMOTION_QUEEN:
-                // Fall-through
-            case PAWN_PROMOTION_QUEEN_CAPTURE:
-                runner->score = QUEEN_PROMOTION_SCORE;
-                break;
-            default: // Non queen promotion
-                runner->score = NON_QUEEN_PROMOTION_SCORE;
-                assert(runner->move.is_promotion());
-                break;
+        if (runner->move == m_killer1)
+            runner->score = KILLER_1_SCORE;
+        else if (runner->move == m_killer2)
+            runner->score = KILLER_2_SCORE;
+        else if (runner->move == m_counter)
+            runner->score = COUNTER_SCORE;
+        else
+            runner->score = m_td->search_history.get_history(*m_td, runner->move);
+    }
+}
+
+void MovePicker::score_noisy_moves() {
+    for (ScoredMove *runner = m_curr; runner != m_end; ++runner) {
+        const Move &move = runner->move;
+        const Piece captured = [&]() {
+            if (move.is_ep())
+                return WHITE_PAWN; // color does not matter
+            else
+                return m_td->position.consult(move.to());
+        }();
+
+        runner->score =
+            CAPTURE_SCORE + 20 * SEE_VALUES[captured] + m_td->search_history.get_capture_history(m_td->position, move);
+
+        if (move.is_promotion()) {
+            runner->score += SEE_VALUES[move.promotee()] - SEE_VALUES[WHITE_PAWN];
         }
     }
 }

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -24,8 +24,6 @@
 
 enum BaseScore {
     TT_SCORE = 100'000,
-    QUEEN_PROMOTION_SCORE = 90'000,
-    NON_QUEEN_PROMOTION_SCORE = -90'000,
     CAPTURE_SCORE = 20'000,
     KILLER_1_SCORE = 19'000,
     KILLER_2_SCORE = 18'000,
@@ -56,7 +54,8 @@ class MovePicker {
 
   private:
     void sort_next_move();
-    void score_moves();
+    void score_quiet_moves();
+    void score_noisy_moves();
 
     bool m_qsearch;
     MovePickerStage m_stage;


### PR DESCRIPTION
Should have been non-regressive.
```
Elo   | 0.77 +- 1.88 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=64MB
LLR   | -0.05 (-2.89, 2.25) [0.00, 3.00]
Games | N: 36678 W: 8667 L: 8586 D: 19425
Penta | [218, 4271, 9241, 4430, 179]
```

https://eduardomarinho.dev/test/388/