### PR TITLE
Fix bug related to probcut not skipping excluded move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -277,9 +277,9 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             MovePicker move_picker(ttmove, td, true, pc_beta - node.static_eval);
             Move move;
             while ((move = move_picker.next_move(true)) != MOVE_NONE) {
-                if (!position.is_legal(move)) { // Avoid illegal moves
+                if (move == td.nodes[td.height].excluded_move || !position.is_legal(move)) { // Avoid illegal moves
                     continue;
-                }
+                } 
                 position.make_move<true>(move);
 
                 node.curr_pmove.move = move;


### PR DESCRIPTION
```
Elo   | 2.65 +- 2.20 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=64MB
LLR   | 2.27 (-2.89, 2.25) [0.00, 3.00]
Games | N: 24136 W: 5656 L: 5472 D: 13008
Penta | [88, 2577, 6565, 2739, 99]
```

https://eduardomarinho.dev/test/409/

Bench: 6895441