### PR TITLE
Only perform tt cutoff in case score is smaller than alpha or cutnode

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -205,7 +205,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
     IndexType ttbound = tthit ? tte.bound() : static_cast<IndexType>(BOUND_EMPTY);
     IndexType ttdepth = tthit ? tte.depth() : 0;
     const bool ttpv = pv_node || (tthit && tte.was_pv());
-    if (!pv_node && !singular_search && tthit && ttdepth >= depth &&
+    if (!pv_node && !singular_search && tthit && ttdepth >= depth  && (ttscore <= alpha || cutnode) &&
         (ttbound == EXACT || (ttbound == UPPER && ttscore <= alpha) || (ttbound == LOWER && ttscore >= beta))) {
         return ttscore;
     }


### PR DESCRIPTION
```
Elo   | 2.25 +- 1.98 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=256MB
LLR   | 2.28 (-2.89, 2.25) [0.00, 3.00]
Games | N: 33672 W: 7909 L: 7691 D: 18072
Penta | [162, 3975, 8392, 4097, 210]
```

https://eduardomarinho.dev/test/413/

Bench: 6760154