### PR TITLE
Improve ordering of quiet moves 

### DIFF
--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -23,6 +23,7 @@
 #include "move.h"
 #include "movegen.h"
 #include "search.h"
+#include "tune.h"
 #include "types.h"
 
 MovePicker::MovePicker(Move ttmove, ThreadData &td, bool qsearch, ScoreType threshold) {
@@ -59,7 +60,7 @@ ScoredMove MovePicker::next_move_scored(const bool &skip_quiets) {
         case PICK_TT:
             m_stage = GEN_NOISY;
             if ((!skip_quiets || m_ttmove.is_noisy()) && m_td->position.is_pseudo_legal(m_ttmove)) {
-                return {m_ttmove, TT_SCORE};
+                return {m_ttmove, 0};
             } else {
             }
             // Fall-through
@@ -134,14 +135,13 @@ void MovePicker::sort_next_move() {
 
 void MovePicker::score_quiet_moves() {
     for (ScoredMove *runner = m_curr; runner != m_end; ++runner) {
+        runner->score = m_td->search_history.get_history(*m_td, runner->move);
         if (runner->move == m_killer1)
-            runner->score = KILLER_1_SCORE;
+            runner->score += mp_killer1_bonus();
         else if (runner->move == m_killer2)
-            runner->score = KILLER_2_SCORE;
+            runner->score += mp_killer2_bonus();
         else if (runner->move == m_counter)
-            runner->score = COUNTER_SCORE;
-        else
-            runner->score = m_td->search_history.get_history(*m_td, runner->move);
+            runner->score += mp_counter_bonus();
     }
 }
 
@@ -156,7 +156,7 @@ void MovePicker::score_noisy_moves() {
         }();
 
         runner->score =
-            CAPTURE_SCORE + 20 * SEE_VALUES[captured] + m_td->search_history.get_capture_history(m_td->position, move);
+            20'000 + 20 * SEE_VALUES[captured] + m_td->search_history.get_capture_history(m_td->position, move);
 
         if (move.is_promotion()) {
             runner->score += SEE_VALUES[move.promotee()] - SEE_VALUES[WHITE_PAWN];

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -22,14 +22,6 @@
 #include "search.h"
 #include "types.h"
 
-enum BaseScore {
-    TT_SCORE = 100'000,
-    CAPTURE_SCORE = 20'000,
-    KILLER_1_SCORE = 19'000,
-    KILLER_2_SCORE = 18'000,
-    COUNTER_SCORE = 17'000,
-};
-
 enum MovePickerStage {
     PICK_TT,
     GEN_NOISY,

--- a/src/tune.h
+++ b/src/tune.h
@@ -206,4 +206,9 @@ TUNABLE_PARAM(rook_scaling_factor, 517, 400, 800, 20, 0.002)
 TUNABLE_PARAM(queen_scaling_factor, 1008, 800, 1400, 30, 0.002)
 TUNABLE_PARAM(material_scaling_base, 25337, 20000, 40000, 1000, 0.002)
 
+// Move picker
+TUNABLE_PARAM(mp_killer1_bonus, 3000, 0, 16000, 400, 0.002)
+TUNABLE_PARAM(mp_killer2_bonus, 2000, 0, 16000, 400, 0.002)
+TUNABLE_PARAM(mp_counter_bonus, 1000, 0, 16000, 400, 0.002)
+
 #endif // #ifndef TUNE_H

--- a/src/tune.h
+++ b/src/tune.h
@@ -207,8 +207,8 @@ TUNABLE_PARAM(queen_scaling_factor, 1008, 800, 1400, 30, 0.002)
 TUNABLE_PARAM(material_scaling_base, 25337, 20000, 40000, 1000, 0.002)
 
 // Move picker
-TUNABLE_PARAM(mp_killer1_bonus, 3000, 0, 16000, 400, 0.002)
-TUNABLE_PARAM(mp_killer2_bonus, 2000, 0, 16000, 400, 0.002)
-TUNABLE_PARAM(mp_counter_bonus, 1000, 0, 16000, 400, 0.002)
+TUNABLE_PARAM(mp_killer1_bonus, 9000, 0, 16000, 400, 0.002)
+TUNABLE_PARAM(mp_killer2_bonus, 6000, 0, 16000, 400, 0.002)
+TUNABLE_PARAM(mp_counter_bonus, 3000, 0, 16000, 400, 0.002)
 
 #endif // #ifndef TUNE_H


### PR DESCRIPTION
Unfinished test. Approving anyway because this fixes some weird behavior of the move picker related to ordering killers and counter moves, also this should improve after SPSA tunes.
```
Elo   | 0.50 +- 2.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.87 (-2.89, 2.25) [0.00, 4.00]
Games | N: 24886 W: 5749 L: 5713 D: 13424
Penta | [141, 2935, 6255, 2971, 141]
```

https://eduardomarinho.dev/test/458/