### PR TITLE
Add non pawn correction history

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -23,9 +23,8 @@
 #include <cstdlib>
 #include <cstring>
 
-#include "position.h"
-#include "types.h"
 #include "move.h"
+#include "position.h"
 #include "search.h"
 #include "tune.h"
 #include "types.h"
@@ -49,6 +48,8 @@ void History::reset() {
     std::memset(m_search_history_table, 0, sizeof(m_search_history_table));
     std::memset(m_continuation_history, 0, sizeof(m_continuation_history));
     std::memset(m_pawn_corr_hist, 0, sizeof(m_pawn_corr_hist));
+    std::memset(m_white_nonpawn_corr_hist, 0, sizeof(m_white_nonpawn_corr_hist));
+    std::memset(m_black_nonpawn_corr_hist, 0, sizeof(m_black_nonpawn_corr_hist));
     std::memset(m_killer_moves, MOVE_NONE.internal(), sizeof(m_killer_moves));
     for (Move &move : m_counter_moves)
         move = MOVE_NONE;
@@ -60,7 +61,11 @@ HistoryType History::get_history(const ThreadData &td, const Move &move) const {
 }
 
 HistoryType History::get_corr_history(const Position &position) const {
-    return pawn_corr_factor() * get_pawn_corr_hist(position) / CORRHIST_GRAIN;
+    int adjustment = pawn_corr_factor() * get_pawn_corr_hist(position);
+    adjustment += nonpawn_corr_factor() * get_white_nonpawn_corr_hist(position);
+    adjustment += nonpawn_corr_factor() * get_black_nonpawn_corr_hist(position);
+
+    return adjustment / CORRHIST_GRAIN;
 }
 
 void History::update_history(const ThreadData &td, const Move &best_move, int depth, const PieceMoveList &quiets_tried,
@@ -109,6 +114,8 @@ void History::update_corr_history(const ThreadData &td, int depth, int diff) {
     HistoryType bonus = std::clamp(diff * depth / 8, -CORRHIST_MAX / 4, CORRHIST_MAX / 4);
 
     update_corrhist_entry(get_pawn_corr_hist(td.position), bonus);
+    update_corrhist_entry(get_white_nonpawn_corr_hist(td.position), bonus);
+    update_corrhist_entry(get_black_nonpawn_corr_hist(td.position), bonus);
 }
 
 void History::update_capture_history_score(const Position &position, const Move &move, int bonus) {

--- a/src/history.h
+++ b/src/history.h
@@ -87,6 +87,18 @@ class History {
     inline HistoryType get_pawn_corr_hist(const Position &pos) const {
         return m_pawn_corr_hist[pos.get_stm()][pos.get_pawn_hash() % CORRHIST_SIZE];
     }
+    inline HistoryType &get_white_nonpawn_corr_hist(const Position &pos) {
+        return m_white_nonpawn_corr_hist[pos.get_stm()][pos.get_white_nonpawn_hash() % CORRHIST_SIZE];
+    }
+    inline HistoryType get_white_nonpawn_corr_hist(const Position &pos) const {
+        return m_white_nonpawn_corr_hist[pos.get_stm()][pos.get_white_nonpawn_hash() % CORRHIST_SIZE];
+    }
+    inline HistoryType &get_black_nonpawn_corr_hist(const Position &pos) {
+        return m_black_nonpawn_corr_hist[pos.get_stm()][pos.get_black_nonpawn_hash() % CORRHIST_SIZE];
+    }
+    inline HistoryType get_black_nonpawn_corr_hist(const Position &pos) const {
+        return m_black_nonpawn_corr_hist[pos.get_stm()][pos.get_black_nonpawn_hash() % CORRHIST_SIZE];
+    }
 
     inline void save_killer(const Move &move, const int height) {
         m_killer_moves[height][1] = m_killer_moves[height][0];
@@ -102,6 +114,8 @@ class History {
     HistoryType m_search_history_table[COLOR_NB][64 * 64];
     HistoryType m_continuation_history[12 * 64][12 * 64];
     HistoryType m_pawn_corr_hist[2][CORRHIST_SIZE];
+    HistoryType m_white_nonpawn_corr_hist[2][CORRHIST_SIZE];
+    HistoryType m_black_nonpawn_corr_hist[2][CORRHIST_SIZE];
     Move m_counter_moves[64 * 64];
     Move m_killer_moves[MAX_SEARCH_DEPTH][2];
 };

--- a/src/position.h
+++ b/src/position.h
@@ -89,8 +89,8 @@ class Position {
     inline Square get_en_passant() const { return m_curr_state.en_passant; }
     inline HashType get_hash() const { return m_position_hash; }
     inline HashType get_pawn_hash() const { return m_pawn_hash; }
-    inline HashType get_white_non_pawn_hash() const { return m_white_non_pawn_hash; }
-    inline HashType get_black_non_pawn_hash() const { return m_black_non_pawn_hash; }
+    inline HashType get_white_nonpawn_hash() const { return m_white_non_pawn_hash; }
+    inline HashType get_black_nonpawn_hash() const { return m_black_non_pawn_hash; }
     inline int get_game_ply() const { return m_game_clock_ply; }
     inline int get_fifty_move_ply() const { return m_curr_state.fifty_move_ply; }
     inline int get_material_count(const Piece &piece) const { return count_bits(get_piece_bb(piece)); }

--- a/src/tune.h
+++ b/src/tune.h
@@ -193,6 +193,7 @@ TUNABLE_PARAM(capt_hist_penalty_offset, 44, -512, 512, 50, 0.002)
 TUNABLE_PARAM(capt_hist_penalty_max, -1176, -3500, -500, 150, 0.002)
 
 TUNABLE_PARAM(pawn_corr_factor, 30, 1, 300, 15, 0.002)
+TUNABLE_PARAM(nonpawn_corr_factor, 40, 1, 300, 15, 0.002)
 
 // Time Manager
 TUNABLE_PARAM(node_tm_base, 191, 150, 300, 7, 0.002)


### PR DESCRIPTION
```
Elo   | 22.19 +- 8.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.29 (-2.89, 2.25) [0.00, 4.00]
Games | N: 1740 W: 475 L: 364 D: 901
Penta | [7, 154, 443, 253, 13]
```
https://eduardomarinho.dev/test/467/

Bench: 7011464