### PR TITLE
Don't store search results on TT during singular searches

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -442,7 +442,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
         td.correction_history.update(td, depth, best_score - eval);
     }
 
-    if (!stop_search(td)) { // Save on TT if search was completed
+    if (!stop_search(td) && !singular_search) {
         td.tt.store(position.get_hash(), depth, best_move, best_score, raw_eval, bound, ttpv, td.tt.age());
         td.best_move = best_move;
     }


### PR DESCRIPTION
```
Elo   | 0.60 +- 2.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.35 (-2.89, 2.25) [0.00, 5.00]
Games | N: 24190 W: 5665 L: 5623 D: 12902
Penta | [97, 2877, 6126, 2877, 118]
```
https://eduardomarinho.dev/test/506/

Bench: 5283624

Test is unfinished, but I this change is very reasonable and small. Also, it seems to be positive even with a lot of noisy in the test that affected it negatively (reason why I don't bother finishing it). 