### PR TITLE
Late move pruning for quiescence search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -513,6 +513,9 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
         ++moves_searched;
 
         if (best_score > -MATE_FOUND) {
+            if (moves_searched >= 3) // late move pruning
+                break;
+
             ScoreType futility = static_eval + qs_futility_margin();
             if (!in_check && futility <= alpha && !SEE(position, move, 1)) {
                 best_score = std::max(best_score, futility);


### PR DESCRIPTION
```
Elo   | 3.01 +- 2.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.28 (-2.89, 2.25) [0.00, 5.00]
Games | N: 17088 W: 4126 L: 3978 D: 8984
Penta | [60, 2026, 4255, 2112, 91]
```
https://eduardomarinho.dev/test/508/

Bench: 6211973