### PR TITLE
More optimistic replacement strategy for tt entries that is/was pv

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -35,7 +35,7 @@ void TTEntry::store(const HashType &hash, const IndexType &depth, const Move &be
     if (best_move != MOVE_NONE || !tthit)
         m_best_move = best_move;
 
-    if (!tthit || bound == EXACT || depth + 4 > m_depth || age != this->age()) {
+    if (!tthit || bound == EXACT || depth + 4 + 2 * was_pv > m_depth || age != this->age()) {
         m_key = key_from_hash(hash);
         m_depth = depth;
         m_score = score;


### PR DESCRIPTION
```
Elo   | 4.37 +- 3.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.26 (-2.89, 2.25) [0.00, 5.00]
Games | N: 9624 W: 2309 L: 2188 D: 5127
Penta | [47, 1126, 2345, 1247, 47]
```
https://eduardomarinho.dev/test/510/

Bench: 6461050