### PR TITLE
TT replacement strategy based on age

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -78,13 +78,16 @@ void TranspositionTable::store(const HashType &hash, const IndexType &depth, con
 
     bool tthit = false;
     for (IndexType index = 0; index < BUCKET_SIZE; ++index) {
-        if (bucket->entry[index].key() == target_key) {
-            replace = &bucket->entry[index];
+        TTEntry *curr = &bucket->entry[index];
+        if (curr->key() == target_key) {
+            replace = curr;
             tthit = true;
             break;
         }
-        if (replace->depth() > bucket->entry[index].depth())
-            replace = &bucket->entry[index];
+        if (replace->depth() - ((MAX_AGE + m_age - replace->age()) & AGE_MASK) * 4 >
+            curr->depth() - ((MAX_AGE + m_age - curr->age()) & AGE_MASK) * 4) {
+            replace = curr;
+        }
     }
     replace->store(hash, depth, best_move, score, eval, bound, was_pv, age, tthit);
 }


### PR DESCRIPTION

#### LTC  256mb
```
Elo   | 3.84 +- 3.30 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=256MB
LLR   | 2.28 (-2.89, 2.25) [0.00, 5.00]
Games | N: 10494 W: 2373 L: 2257 D: 5864
Penta | [23, 1148, 2781, 1280, 15]
```
https://eduardomarinho.dev/test/516/
#### STC 32mb (unfinished)
```
Elo   | 1.10 +- 2.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.38 (-2.89, 2.25) [0.00, 5.00]
Games | N: 24312 W: 5693 L: 5616 D: 13003
Penta | [100, 2822, 6237, 2895, 102]
```
https://eduardomarinho.dev/test/515/

Bench: 6993924