### PR TITLE
Perform negative extension if singular search failed and ttscore is above beta

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -346,6 +346,8 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                     extension = 2;
             } else if (singular_score >= beta) { // Multi-Cut
                 return singular_score;
+            } else if (ttscore >= beta) {
+                extension = -2;
             } else if (cutnode) {
                 extension = -2;
             }


### PR DESCRIPTION
#### STC
```
Elo   | 0.26 +- 3.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.88 (-2.89, 2.25) [0.00, 5.00]
Games | N: 10640 W: 2462 L: 2454 D: 5724
Penta | [48, 1262, 2694, 1266, 50]
```
https://eduardomarinho.dev/test/519/

#### LTC
```
Elo   | 5.02 +- 3.94 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.30 (-2.89, 2.25) [0.00, 5.00]
Games | N: 7200 W: 1673 L: 1569 D: 3958
Penta | [8, 785, 1909, 891, 7]
```
https://eduardomarinho.dev/test/520/

Bench: 6766383