### PR TITLE
Perform singular search triple extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -343,7 +343,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                 extension = 1;
 
                 if (!pv_node && singular_score < beta - double_extension_margin())
-                    extension = 2;
+                    extension = 2 + (singular_score < singular_beta - triple_ext_margin());
             } else if (singular_score >= beta) { // Multi-Cut
                 return singular_score;
             } else if (ttscore >= beta) {

--- a/src/tune.h
+++ b/src/tune.h
@@ -155,6 +155,7 @@ TUNABLE_PARAM(lmp_improving_scale, 73, 40, 240, 5, 0.002)
 FIXED_PARAM(singular_extension_min_depth, 8, 4, 10, 0.5, 0.002)
 TUNABLE_PARAM(singular_extension_depth_factor, 16, 10, 20, 1, 0.002)
 TUNABLE_PARAM(double_extension_margin, 10, -20, 40, 3, 0.002)
+TUNABLE_PARAM(triple_ext_margin, 100, 40, 140, 5, 0.002)
 
 // Razoring
 TUNABLE_PARAM(razoring_max_depth, 5, 2, 6, 0.5, 0.002)


### PR DESCRIPTION
#### STC
```
Elo   | 0.68 +- 2.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.18 (-2.89, 2.25) [0.00, 5.00]
Games | N: 23860 W: 5598 L: 5551 D: 12711
Penta | [99, 2845, 5986, 2910, 90]
```
https://eduardomarinho.dev/test/522/

#### LTC
```
Elo   | 0.28 +- 2.77 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.21 (-2.89, 2.25) [0.00, 5.00]
Games | N: 15038 W: 3374 L: 3362 D: 8302
Penta | [16, 1791, 3901, 1787, 24]
```
https://eduardomarinho.dev/test/521/

Bench: 6541981

yolo;
Does not look good, but it make sense and should improve with future SPSA tunes.