### PR TITLE
Fix double extension condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -342,7 +342,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             if (singular_score < singular_beta) {
                 extension = 1;
 
-                if (!pv_node && singular_score < beta - double_extension_margin())
+                if (!pv_node && singular_score < singular_beta - double_extension_margin())
                     extension = 2 + (singular_score < singular_beta - triple_ext_margin());
             } else if (singular_score >= beta) { // Multi-Cut
                 return singular_score;


### PR DESCRIPTION
```
Elo   | 8.54 +- 5.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.28 (-2.89, 2.25) [0.00, 5.00]
Games | N: 4030 W: 958 L: 859 D: 2213
Penta | [18, 437, 1008, 532, 20]
```
https://eduardomarinho.dev/test/525/

Bench: 7251187