### PR TITLE
Better condition for improving heuristic

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -238,8 +238,15 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
     td.nodes[td.height + 1].excluded_move = MOVE_NONE;
     td.search_history.clear_killers(td.height + 1);
 
-    bool improving = td.height >= 2 && (node.static_eval > td.nodes[td.height - 2].static_eval ||
-                                        td.nodes[td.height - 2].static_eval == SCORE_NONE);
+    bool improving = [&]() -> bool {
+        if (!in_check) {
+            if (td.height >= 2 && td.nodes[td.height - 2].static_eval != SCORE_NONE)
+                return node.static_eval > td.nodes[td.height - 2].static_eval;
+            if (td.height >= 4 && td.nodes[td.height - 4].static_eval != SCORE_NONE)
+                return node.static_eval > td.nodes[td.height - 4].static_eval;
+        }
+        return false;
+    }();
 
     // Forward pruning methods
     if (!in_check && !pv_node && !root && !singular_search) {


### PR DESCRIPTION
```
Elo   | 3.95 +- 2.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 14178 W: 3290 L: 3129 D: 7759
Penta | [44, 1661, 3535, 1788, 61]
```
https://eduardomarinho.dev/test/550/

Bench: 5428681