### PR TITLE
Simplify negamax static_eval and correctly use it in correction history updates

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -484,24 +484,22 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
     }
 
     bool in_check = position.in_check();
-    ScoreType best_score, static_eval, raw_eval;
+    ScoreType best_score, raw_eval;
     if (in_check) {
-        static_eval = node.static_eval = raw_eval = SCORE_NONE;
+        node.static_eval = raw_eval = SCORE_NONE;
         best_score = -MAX_SCORE;
     } else if (tthit) {
         raw_eval = tteval != SCORE_NONE ? tteval : position.eval();
-        best_score = static_eval = node.static_eval =
-            adjust_eval(position, raw_eval, td.correction_history.correction(td));
+        best_score = node.static_eval = adjust_eval(position, raw_eval, td.correction_history.correction(td));
 
-        if (ttscore != SCORE_NONE && (ttbound == EXACT || (ttbound == UPPER && ttscore < static_eval) ||
-                                      (ttbound == LOWER && ttscore > static_eval))) {
+        if (ttscore != SCORE_NONE && (ttbound == EXACT || (ttbound == UPPER && ttscore < best_score) ||
+                                      (ttbound == LOWER && ttscore > best_score))) {
             best_score = ttscore;
         }
 
     } else {
         raw_eval = position.eval();
-        best_score = static_eval = node.static_eval =
-            adjust_eval(position, raw_eval, td.correction_history.correction(td));
+        best_score = node.static_eval = adjust_eval(position, raw_eval, td.correction_history.correction(td));
         td.tt.store(position.get_hash(), 0, MOVE_NONE, SCORE_NONE, raw_eval, BOUND_EMPTY, ttpv, td.tt.age());
     }
 
@@ -525,7 +523,7 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
             if (moves_searched >= 3) // late move pruning
                 break;
 
-            ScoreType futility = static_eval + qs_futility_margin();
+            ScoreType futility = node.static_eval + qs_futility_margin();
             if (!in_check && futility <= alpha && !SEE(position, move, 1)) {
                 best_score = std::max(best_score, futility);
                 continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -447,8 +447,9 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
     const BoundType bound = best_score >= beta ? LOWER : (alpha != old_alpha ? EXACT : UPPER);
     if (!in_check && (best_move == MOVE_NONE || best_move.is_quiet()) &&
-        (bound == EXACT || (bound == LOWER && best_score > eval) || (bound == UPPER && best_score < eval))) {
-        td.correction_history.update(td, depth, best_score - eval);
+        (bound == EXACT || (bound == LOWER && best_score > node.static_eval) ||
+         (bound == UPPER && best_score < node.static_eval))) {
+        td.correction_history.update(td, depth, best_score - node.static_eval);
     }
 
     if (!stop_search(td) && !singular_search) {


### PR DESCRIPTION
```
Elo   | 3.32 +- 2.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.30 (-2.89, 2.25) [0.00, 5.00]
Games | N: 14456 W: 3309 L: 3171 D: 7976
Penta | [45, 1703, 3621, 1787, 72]
```
https://eduardomarinho.dev/test/556/

Bench: 5228626