### PR TITLE
Search history pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -325,7 +325,8 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                 skip_quiets = true;
             }
 
-            const CounterType lmr_scaled_depth = LMR_TABLE[std::min(depth, 63)][std::min(moves_searched, 63)];
+            const CounterType lmr_scaled_depth =
+                depth * 1024 - LMR_TABLE[std::min(depth, 63)][std::min(moves_searched, 63)];
 
             // Quiet History Pruning
             if (lmr_scaled_depth <= history_pruning_max_depth_scaled() && move.is_quiet() &&

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -324,6 +324,16 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             if (moves_searched > LMP_TABLE[improving][std::min(depth, LMP_DEPTH - 1)]) {
                 skip_quiets = true;
             }
+
+            const CounterType lmr_scaled_depth = LMR_TABLE[std::min(depth, 63)][std::min(moves_searched, 63)];
+
+            // Quiet History Pruning
+            if (lmr_scaled_depth <= history_pruning_max_depth_scaled() && move.is_quiet() &&
+                td.search_history.get_history(td, move) <
+                    quiet_hist_pruning_factor() * depth + quiet_hist_pruning_base()) {
+                skip_quiets = true;
+                continue;
+            }
         }
 
         // Extensions

--- a/src/tune.h
+++ b/src/tune.h
@@ -151,6 +151,11 @@ TUNABLE_PARAM(lmp_scale, 39, 20, 120, 5, 0.002)
 TUNABLE_PARAM(lmp_improving_base, 259, 200, 400, 5, 0.002)
 TUNABLE_PARAM(lmp_improving_scale, 73, 40, 240, 5, 0.002)
 
+// Quiet History Pruning
+TUNABLE_PARAM(history_pruning_max_depth_scaled, 5000, 2500, 10000, 300, 0.002)
+TUNABLE_PARAM(quiet_hist_pruning_factor, -2500, -5000, -1000, 200, 0.002)
+TUNABLE_PARAM(quiet_hist_pruning_base, -1000, -2500, -500, 100, 0.002)
+
 // Singular Extension
 FIXED_PARAM(singular_extension_min_depth, 8, 4, 10, 0.5, 0.002)
 TUNABLE_PARAM(singular_extension_depth_factor, 17, 10, 20, 1, 0.002)

--- a/src/tune.h
+++ b/src/tune.h
@@ -153,8 +153,8 @@ TUNABLE_PARAM(lmp_improving_scale, 73, 40, 240, 5, 0.002)
 
 // Quiet History Pruning
 TUNABLE_PARAM(history_pruning_max_depth_scaled, 5000, 2500, 10000, 300, 0.002)
-TUNABLE_PARAM(quiet_hist_pruning_factor, -2500, -5000, -1000, 200, 0.002)
-TUNABLE_PARAM(quiet_hist_pruning_base, -1000, -2500, -500, 100, 0.002)
+TUNABLE_PARAM(quiet_hist_pruning_factor, -1500, -5000, -500, 200, 0.002)
+TUNABLE_PARAM(quiet_hist_pruning_base, -400, -2500, 0, 100, 0.002)
 
 // Singular Extension
 FIXED_PARAM(singular_extension_min_depth, 8, 4, 10, 0.5, 0.002)


### PR DESCRIPTION
#### STC 
```
Elo   | -2.75 +- 3.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9350 W: 2100 L: 2174 D: 5076
Penta | [39, 1146, 2371, 1088, 31]
```
https://eduardomarinho.dev/test/546/

#### LTC
```
Elo   | 1.42 +- 2.35 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.32 (-2.94, 2.94) [0.00, 5.00]
Games | N: 20554 W: 4562 L: 4478 D: 11514
Penta | [15, 2395, 5383, 2459, 25]
```
https://eduardomarinho.dev/test/547/


It doesn't look great, however it seems to scale and it adds tunable values (the history pruning params), so this should improve a lot after a SPSA tune.