### PR TITLE
Add SEE pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -334,6 +334,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
             const CounterType lmr_scaled_depth =
                 depth * 1024 - LMR_TABLE[std::min(depth, 63)][std::min(moves_searched, 63)];
+            const CounterType lmr_depth = lmr_scaled_depth / 1024;
 
             // Quiet History Pruning
             if (lmr_scaled_depth <= history_pruning_max_depth_scaled() && move.is_quiet() &&
@@ -342,6 +343,11 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                 skip_quiets = true;
                 continue;
             }
+
+            int see_margin = (move.is_quiet() ? see_quiet_pruning_factor() * lmr_depth
+                                              : see_noisy_pruning_factor() * lmr_depth * lmr_depth);
+            if (!SEE(position, move, see_margin))
+                continue;
         }
 
         // Extensions

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -344,9 +344,8 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                 continue;
             }
 
-            int see_margin = (move.is_quiet() ? see_quiet_pruning_factor() * lmr_depth
-                                              : see_noisy_pruning_factor() * lmr_depth * lmr_depth);
-            if (!SEE(position, move, see_margin))
+            const int see_margin = see_noisy_pruning_factor() * lmr_depth * lmr_depth;
+            if (move_picker.picker_stage() >= PICK_BAD_NOISY && !SEE(position, move, see_margin))
                 continue;
         }
 

--- a/src/tune.h
+++ b/src/tune.h
@@ -156,6 +156,10 @@ TUNABLE_PARAM(history_pruning_max_depth_scaled, 5000, 2500, 10000, 300, 0.002)
 TUNABLE_PARAM(quiet_hist_pruning_factor, -1500, -5000, -500, 200, 0.002)
 TUNABLE_PARAM(quiet_hist_pruning_base, -400, -2500, 0, 100, 0.002)
 
+// SEE pruning
+TUNABLE_PARAM(see_quiet_pruning_factor, -100, -200, 50, 10, 0.002)
+TUNABLE_PARAM(see_noisy_pruning_factor, -20, -200, 50, 10, 0.002)
+
 // Singular Extension
 FIXED_PARAM(singular_extension_min_depth, 8, 4, 10, 0.5, 0.002)
 TUNABLE_PARAM(singular_extension_depth_factor, 17, 10, 20, 1, 0.002)


### PR DESCRIPTION
```
Elo   | 3.33 +- 2.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.04 (-2.25, 2.89) [0.00, 5.00]
Games | N: 19088 W: 4523 L: 4340 D: 10225
Penta | [77, 2234, 4731, 2433, 69]
```
https://eduardomarinho.dev/test/568/

Bench: 5532515