### PR TITLE
Add continuation correction

### DIFF
--- a/src/correction.cpp
+++ b/src/correction.cpp
@@ -48,7 +48,7 @@ void CorrectionHistory::update(const ThreadData& td, const int depth, const int 
         const PieceMove pmove2 = td.nodes[td.height - 2].curr_pmove;
 
         if (pmove1 != PIECE_MOVE_NONE && pmove2 != PIECE_MOVE_NONE) {
-            m_cont_corr[cont_corr_idx(pmove1)][cont_corr_idx(pmove2)].update(bonus);
+            tables.cont_corr[cont_corr_idx(pmove1)][cont_corr_idx(pmove2)].update(bonus);
         }
     }
 }
@@ -64,7 +64,7 @@ HistoryType CorrectionHistory::correction(const ThreadData& td) const {
         const PieceMove pmove1 = td.nodes[td.height - 1].curr_pmove;
         const PieceMove pmove2 = td.nodes[td.height - 2].curr_pmove;
         if (pmove1 != PIECE_MOVE_NONE && pmove2 != PIECE_MOVE_NONE) {
-            adjustment += cont_corr_factor() * m_cont_corr[cont_corr_idx(pmove1)][cont_corr_idx(pmove2)];
+            adjustment += cont_corr_factor() * tables.cont_corr[cont_corr_idx(pmove1)][cont_corr_idx(pmove2)];
         }
     }
 

--- a/src/correction.cpp
+++ b/src/correction.cpp
@@ -20,6 +20,7 @@
 
 #include <cstring>
 
+#include "move.h"
 #include "position.h"
 #include "search.h"
 #include "tune.h"
@@ -37,6 +38,15 @@ void CorrectionHistory::update(const ThreadData& td, const int depth, const int 
     tables.pawn[td.position.get_pawn_hash() % CORRHIST_SIZE].update(bonus);
     tables.white_nonpawn[td.position.get_white_nonpawn_hash() % CORRHIST_SIZE].update(bonus);
     tables.black_nonpawn[td.position.get_black_nonpawn_hash() % CORRHIST_SIZE].update(bonus);
+
+    if (td.height >= 2) {
+        const PieceMove pmove1 = td.nodes[td.height - 1].curr_pmove;
+        const PieceMove pmove2 = td.nodes[td.height - 2].curr_pmove;
+
+        if (pmove1 != PIECE_MOVE_NONE && pmove2 != PIECE_MOVE_NONE) {
+            m_cont_corr[pmove1.piece * pmove1.move.to()][pmove2.piece * pmove1.move.to()].update(bonus);
+        }
+    }
 }
 
 HistoryType CorrectionHistory::correction(const ThreadData& td) const {
@@ -45,6 +55,15 @@ HistoryType CorrectionHistory::correction(const ThreadData& td) const {
     HistoryType adjustment = pawn_corr_factor() * tables.pawn[td.position.get_pawn_hash() % CORRHIST_SIZE];
     adjustment += nonpawn_corr_factor() * tables.white_nonpawn[td.position.get_white_nonpawn_hash() % CORRHIST_SIZE];
     adjustment += nonpawn_corr_factor() * tables.black_nonpawn[td.position.get_black_nonpawn_hash() % CORRHIST_SIZE];
+
+    if (td.height >= 2) {
+        const PieceMove pmove1 = td.nodes[td.height - 1].curr_pmove;
+        const PieceMove pmove2 = td.nodes[td.height - 2].curr_pmove;
+        if (pmove1 != PIECE_MOVE_NONE && pmove2 != PIECE_MOVE_NONE) {
+            adjustment +=
+                cont_corr_factor() * m_cont_corr[pmove1.piece * pmove1.move.to()][pmove2.piece * pmove1.move.to()];
+        }
+    }
 
     return adjustment / CORRHIST_GRAIN;
 }

--- a/src/correction.cpp
+++ b/src/correction.cpp
@@ -26,6 +26,10 @@
 #include "tune.h"
 #include "types.h"
 
+static inline size_t cont_corr_idx(const PieceMove& pmove) {
+    return (static_cast<size_t>(pmove.piece) << 6) | static_cast<size_t>(pmove.move.to());
+};
+
 void CorrectionHistory::reset() {
     m_pov_tables = {}; //
 }
@@ -44,7 +48,7 @@ void CorrectionHistory::update(const ThreadData& td, const int depth, const int 
         const PieceMove pmove2 = td.nodes[td.height - 2].curr_pmove;
 
         if (pmove1 != PIECE_MOVE_NONE && pmove2 != PIECE_MOVE_NONE) {
-            m_cont_corr[pmove1.piece * pmove1.move.to()][pmove2.piece * pmove1.move.to()].update(bonus);
+            m_cont_corr[cont_corr_idx(pmove1)][cont_corr_idx(pmove2)].update(bonus);
         }
     }
 }
@@ -60,8 +64,7 @@ HistoryType CorrectionHistory::correction(const ThreadData& td) const {
         const PieceMove pmove1 = td.nodes[td.height - 1].curr_pmove;
         const PieceMove pmove2 = td.nodes[td.height - 2].curr_pmove;
         if (pmove1 != PIECE_MOVE_NONE && pmove2 != PIECE_MOVE_NONE) {
-            adjustment +=
-                cont_corr_factor() * m_cont_corr[pmove1.piece * pmove1.move.to()][pmove2.piece * pmove1.move.to()];
+            adjustment += cont_corr_factor() * m_cont_corr[cont_corr_idx(pmove1)][cont_corr_idx(pmove2)];
         }
     }
 

--- a/src/correction.h
+++ b/src/correction.h
@@ -56,6 +56,7 @@ class CorrectionHistory {
     };
 
     std::array<PovTables, 2> m_pov_tables;
+    std::array<std::array<CorrectionEntry, 64 * 12>, 64 * 12> m_cont_corr{}; // [piece * prev_to][piece * to]
 };
 
 #endif // !CORRECTION_H

--- a/src/correction.h
+++ b/src/correction.h
@@ -53,10 +53,10 @@ class CorrectionHistory {
         std::array<CorrectionEntry, CORRHIST_SIZE> pawn{};
         std::array<CorrectionEntry, CORRHIST_SIZE> white_nonpawn{};
         std::array<CorrectionEntry, CORRHIST_SIZE> black_nonpawn{};
+        std::array<std::array<CorrectionEntry, 64 * 12>, 64 * 12> cont_corr{}; // [piece * prev_to][piece * to]
     };
 
     std::array<PovTables, 2> m_pov_tables;
-    std::array<std::array<CorrectionEntry, 64 * 12>, 64 * 12> m_cont_corr{}; // [piece * prev_to][piece * to]
 };
 
 #endif // !CORRECTION_H

--- a/src/tune.h
+++ b/src/tune.h
@@ -195,6 +195,7 @@ TUNABLE_PARAM(capt_hist_penalty_max, -965, -3500, -500, 150, 0.002)
 
 TUNABLE_PARAM(pawn_corr_factor, 39, 1, 300, 15, 0.002)
 TUNABLE_PARAM(nonpawn_corr_factor, 40, 1, 300, 15, 0.002)
+TUNABLE_PARAM(cont_corr_factor, 25, 1, 300, 15, 0.002)
 
 TUNABLE_PARAM(conthist_1ply_weight, 981, 0, 1536, 100, 0.002)
 TUNABLE_PARAM(conthist_2ply_weight, 1191, 0, 1536, 100, 0.002)


### PR DESCRIPTION
```
Elo   | 0.79 +- 1.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 73764 W: 17004 L: 16836 D: 39924
Penta | [292, 8779, 18578, 8935, 298]
```
https://eduardomarinho.dev/test/553/

yellow patch. 