### PR TITLE
Apply reduction for new depth variable directly and necessary changes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -380,7 +380,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
         position.make_move<true>(move);
 
         td.tt.prefetch(position.get_hash());
-        int new_depth = depth + extension;
+        int new_depth = depth + extension - 1;
 
         // Add move to tried list
         if (move.is_quiet())
@@ -395,9 +395,9 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
         td.nodes[td.height].pv_list.clear();
         ScoreType score;
         if (moves_searched == 1) {
-            score = -negamax(-beta, -alpha, new_depth - 1, false, td);
+            score = -negamax(-beta, -alpha, new_depth, false, td);
         } else {
-            int scaled_reduction = 1024;
+            int scaled_reduction = 0;
             // Late Move Reduction
             if (moves_searched > 1 && depth >= 3 && move.is_quiet()) {
                 scaled_reduction = LMR_TABLE[std::min(depth, 63)][std::min(moves_searched, 63)];
@@ -419,18 +419,18 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             } else {
                 // reduce noisy
             }
-            const int lmr_depth = std::min(std::max(new_depth - scaled_reduction / 1024, 1), new_depth - 1);
+            const int lmr_depth = std::min(std::max(new_depth - scaled_reduction / 1024, 1), new_depth);
             score = -negamax(-alpha - 1, -alpha, lmr_depth, true, td);
 
             if (score > alpha && scaled_reduction > 1024) {
                 new_depth += score > best_score + 35;
-                new_depth -= score < best_score + new_depth;
+                new_depth -= score < best_score + new_depth + 1;
 
-                score = -negamax(-alpha - 1, -alpha, new_depth - 1, !cutnode, td);
+                score = -negamax(-alpha - 1, -alpha, new_depth, !cutnode, td);
             }
 
             if (pv_node && score > alpha) {
-                score = -negamax(-beta, -alpha, new_depth - 1, false, td);
+                score = -negamax(-beta, -alpha, new_depth, false, td);
             }
         }
 

--- a/src/tune.h
+++ b/src/tune.h
@@ -136,7 +136,7 @@ TUNABLE_PARAM(rfp_margin, 107, 50, 150, 10, 0.002)
 FIXED_PARAM(rfp_max_depth, 10, 5, 15, 0.5, 0.002)
 
 // Late Move Reductions
-TUNABLE_PARAM(lmr_base, 1135, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_base, 111, 512, 2048, 128, 0.002)
 TUNABLE_PARAM(lmr_scale, 725, 256, 2048, 128, 0.002)
 TUNABLE_PARAM(lmr_gives_check_delta, 948, 512, 2048, 128, 0.002)
 TUNABLE_PARAM(lmr_non_improving_delta, 1321, 512, 2048, 128, 0.002)


### PR DESCRIPTION
```
Elo   | 1.81 +- 2.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 1.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 24444 W: 5677 L: 5550 D: 13217
Penta | [78, 2896, 6151, 3015, 82]
```
https://eduardomarinho.dev/test/575/

Bench: 5461027

This should have been non-regressive