### PR TITLE
LMR reduction based on correction history score

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -223,20 +223,21 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
     bool in_check = position.in_check();
     ScoreType eval, raw_eval;
+    ScoreType correction_value = td.correction_history.correction(td);
     if (in_check) {
         eval = node.static_eval = raw_eval = SCORE_NONE;
     } else if (singular_search) {
         eval = raw_eval = node.static_eval;
     } else if (tthit) {
         raw_eval = tteval != SCORE_NONE ? tteval : position.eval();
-        eval = node.static_eval = adjust_eval(position, raw_eval, td.correction_history.correction(td));
+        eval = node.static_eval = adjust_eval(position, raw_eval, correction_value);
         if (ttscore != SCORE_NONE &&
             (ttbound == EXACT || (ttbound == UPPER && ttscore < eval) || (ttbound == LOWER && ttscore > eval)))
             eval = ttscore;
 
     } else {
         raw_eval = position.eval();
-        eval = node.static_eval = adjust_eval(position, raw_eval, td.correction_history.correction(td));
+        eval = node.static_eval = adjust_eval(position, raw_eval, correction_value);
         td.tt.store(position.get_hash(), 0, MOVE_NONE, SCORE_NONE, raw_eval, BOUND_EMPTY, ttpv, td.tt.age());
     }
 
@@ -432,6 +433,9 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
                 // Reduce less if this move is or was a principal variation
                 scaled_reduction -= ttpv * lmr_ttpv_delta();
+
+                // Reduce based on correction history.
+                scaled_reduction -= std::abs(correction_value) / lmr_corrhist_divisor();
             } else {
                 // reduce noisy
             }

--- a/src/tune.h
+++ b/src/tune.h
@@ -144,6 +144,7 @@ TUNABLE_PARAM(lmr_cutnode_delta, 769, 512, 2048, 128, 0.002)
 TUNABLE_PARAM(lmr_killer_delta, 1103, 512, 2048, 128, 0.002)
 TUNABLE_PARAM(lmr_counter_delta, 1226, 512, 2048, 128, 0.002)
 TUNABLE_PARAM(lmr_ttpv_delta, 926, 512, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_corrhist_divisor, 512, 0, 2048, 128, 0.002)
 
 // Late Moves Pruning
 TUNABLE_PARAM(lmp_base, 123, 100, 200, 5, 0.002)


### PR DESCRIPTION
```
Elo   | 3.09 +- 2.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 20146 W: 4736 L: 4557 D: 10853
Penta | [91, 2169, 5367, 2362, 84]
https://eduardomarinho.dev/test/593/
```

Bench: 5071730