### PR TITLE
Use new depth as a factor for 'LMR do deeper search' equation

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -443,7 +443,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             score = -negamax(-alpha - 1, -alpha, lmr_depth, true, td);
 
             if (score > alpha && scaled_reduction > 1024) {
-                new_depth += score > best_score + 35;
+                new_depth += score > best_score + lmr_deeper_margin() + lmr_deeper_factor() * new_depth;
                 new_depth -= score < best_score + new_depth + 1;
 
                 score = -negamax(-alpha - 1, -alpha, new_depth, !cutnode, td);

--- a/src/tune.h
+++ b/src/tune.h
@@ -145,6 +145,8 @@ TUNABLE_PARAM(lmr_killer_delta, 1103, 512, 2048, 128, 0.002)
 TUNABLE_PARAM(lmr_counter_delta, 1226, 512, 2048, 128, 0.002)
 TUNABLE_PARAM(lmr_ttpv_delta, 926, 512, 2048, 128, 0.002)
 TUNABLE_PARAM(lmr_corrhist_divisor, 512, 0, 2048, 128, 0.002)
+TUNABLE_PARAM(lmr_deeper_margin, 30, 20, 100, 5, 0.002)
+TUNABLE_PARAM(lmr_deeper_factor, 2, 1, 10, 1, 0.002)
 
 // Late Moves Pruning
 TUNABLE_PARAM(lmp_base, 123, 100, 200, 5, 0.002)


### PR DESCRIPTION
```
Elo   | 2.74 +- 2.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 5.00]
Games | N: 26756 W: 6233 L: 6022 D: 14501
Penta | [94, 3128, 6737, 3311, 108]
https://eduardomarinho.dev/test/604/
```
Bench: 4569074