### PR TITLE
Perform Hindsight reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -257,6 +257,13 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
     // Forward pruning methods
     if (!in_check && !pv_node && !root && !singular_search) {
+        // Hindsight reduction
+        if (depth >= 2 && td.height >= 1 && td.nodes[td.height - 1].reduction >= 1 &&
+            td.nodes[td.height - 1].static_eval != SCORE_NONE &&
+            node.static_eval + td.nodes[td.height - 1].static_eval >= hindsight_eval()) {
+            --depth;
+        }
+
         // Reverse futility pruning
         if (depth < rfp_max_depth() && eval - rfp_margin() * (depth - improving) >= beta)
             return eval;
@@ -439,8 +446,12 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             } else {
                 // reduce noisy
             }
-            const int lmr_depth = std::min(std::max(new_depth - scaled_reduction / 1024, 1), new_depth);
+            const int reduction = scaled_reduction / 1024;
+            const int lmr_depth = std::min(std::max(new_depth - reduction, 1), new_depth);
+
+            td.nodes[td.height - 1].reduction = reduction;
             score = -negamax(-alpha - 1, -alpha, lmr_depth, true, td);
+            td.nodes[td.height - 1].reduction = 0;
 
             if (score > alpha && scaled_reduction > 1024) {
                 new_depth += score > best_score + lmr_deeper_margin() + lmr_deeper_factor() * new_depth;

--- a/src/search.h
+++ b/src/search.h
@@ -47,6 +47,7 @@ struct SearchLimits {
 struct NodeData {
     PieceMove curr_pmove;
     Move excluded_move;
+    CounterType reduction;
     ScoreType static_eval;
     PvList pv_list;
 

--- a/src/tune.h
+++ b/src/tune.h
@@ -131,6 +131,9 @@ TUNABLE_PARAM(nmp_base_reduction, 304, 128, 384, 15, 0.002)
 TUNABLE_PARAM(nmp_depth_factor, 21, 16, 63, 0.5, 0.002)
 FIXED_PARAM(nmp_min_depth, 2, 2, 8, 0.5, 0.002)
 
+// Hindsight
+TUNABLE_PARAM(hindsight_eval, 150, 50, 300, 10, 0.002)
+
 // Reverse Futility Pruning
 TUNABLE_PARAM(rfp_margin, 107, 50, 150, 10, 0.002)
 FIXED_PARAM(rfp_max_depth, 10, 5, 15, 0.5, 0.002)


### PR DESCRIPTION
```
Elo   | 4.04 +- 3.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13688 W: 3271 L: 3112 D: 7305
Penta | [50, 1579, 3423, 1746, 46]
```
https://eduardomarinho.dev/test/634/

Bench: 4786859