### PR TITLE
Compress continuation correction table

### DIFF
--- a/src/correction.cpp
+++ b/src/correction.cpp
@@ -27,7 +27,7 @@
 #include "types.h"
 
 static inline size_t cont_corr_idx(const PieceMove& pmove) {
-    return (static_cast<size_t>(pmove.piece) << 6) | static_cast<size_t>(pmove.move.to());
+    return (static_cast<size_t>(get_piece_type(pmove.piece)) << 6) | static_cast<size_t>(pmove.move.to());
 };
 
 void CorrectionHistory::reset() {

--- a/src/correction.h
+++ b/src/correction.h
@@ -53,7 +53,7 @@ class CorrectionHistory {
         std::array<CorrectionEntry, CORRHIST_SIZE> pawn{};
         std::array<CorrectionEntry, CORRHIST_SIZE> white_nonpawn{};
         std::array<CorrectionEntry, CORRHIST_SIZE> black_nonpawn{};
-        std::array<std::array<CorrectionEntry, 64 * 12>, 64 * 12> cont_corr{}; // [piece * prev_to][piece * to]
+        std::array<std::array<CorrectionEntry, 64 * 6>, 64 * 6> cont_corr{};
     };
 
     std::array<PovTables, 2> m_pov_tables;

--- a/src/move.h
+++ b/src/move.h
@@ -85,7 +85,7 @@ struct MoveList {
 
 struct PieceMove {
     Move move;
-    uint8_t piece;
+    Piece piece;
 
     PieceMove() { PieceMove(MOVE_NONE, EMPTY); }
     PieceMove(const Move& _move, const Piece& _piece) : move(_move), piece(_piece) {}


### PR DESCRIPTION
```
Elo   | 0.09 +- 2.51 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | -1.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 20214 W: 4882 L: 4877 D: 10455
Penta | [113, 2323, 5235, 2318, 118]
```
https://eduardomarinho.dev/test/638/

Bench: 5792628