### PR TITLE
Add follow-up (2-ply) continuation correction 

### DIFF
--- a/src/correction.cpp
+++ b/src/correction.cpp
@@ -53,8 +53,8 @@ void CorrectionHistory::update(const ThreadData& td, const int depth, const int 
             }
         }
     };
-
     update_cont(1);
+    update_cont(2);
 }
 
 HistoryType CorrectionHistory::correction(const ThreadData& td) const {
@@ -74,6 +74,7 @@ HistoryType CorrectionHistory::correction(const ThreadData& td) const {
         }
     };
     adjust_cont(1);
+    adjust_cont(2);
 
     return adjustment / CORRHIST_GRAIN;
 }

--- a/src/correction.cpp
+++ b/src/correction.cpp
@@ -43,14 +43,18 @@ void CorrectionHistory::update(const ThreadData& td, const int depth, const int 
     tables.white_nonpawn[td.position.get_white_nonpawn_hash() % CORRHIST_SIZE].update(bonus);
     tables.black_nonpawn[td.position.get_black_nonpawn_hash() % CORRHIST_SIZE].update(bonus);
 
-    if (td.height >= 2) {
-        const PieceMove pmove1 = td.nodes[td.height - 1].curr_pmove;
-        const PieceMove pmove2 = td.nodes[td.height - 2].curr_pmove;
+    auto update_cont = [&](int offset) {
+        if (td.height >= offset + 1) {
+            const PieceMove curr_pmove = td.nodes[td.height - 1].curr_pmove;
+            const PieceMove past_pmove = td.nodes[td.height - offset - 1].curr_pmove;
 
-        if (pmove1 != PIECE_MOVE_NONE && pmove2 != PIECE_MOVE_NONE) {
-            tables.cont_corr[cont_corr_idx(pmove1)][cont_corr_idx(pmove2)].update(bonus);
+            if (curr_pmove != PIECE_MOVE_NONE && past_pmove != PIECE_MOVE_NONE) {
+                tables.cont_corr[cont_corr_idx(curr_pmove)][cont_corr_idx(past_pmove)].update(bonus);
+            }
         }
-    }
+    };
+
+    update_cont(1);
 }
 
 HistoryType CorrectionHistory::correction(const ThreadData& td) const {
@@ -60,13 +64,16 @@ HistoryType CorrectionHistory::correction(const ThreadData& td) const {
     adjustment += nonpawn_corr_factor() * tables.white_nonpawn[td.position.get_white_nonpawn_hash() % CORRHIST_SIZE];
     adjustment += nonpawn_corr_factor() * tables.black_nonpawn[td.position.get_black_nonpawn_hash() % CORRHIST_SIZE];
 
-    if (td.height >= 2) {
-        const PieceMove pmove1 = td.nodes[td.height - 1].curr_pmove;
-        const PieceMove pmove2 = td.nodes[td.height - 2].curr_pmove;
-        if (pmove1 != PIECE_MOVE_NONE && pmove2 != PIECE_MOVE_NONE) {
-            adjustment += cont_corr_factor() * tables.cont_corr[cont_corr_idx(pmove1)][cont_corr_idx(pmove2)];
+    auto adjust_cont = [&](int offset) {
+        if (td.height >= offset + 1) {
+            const PieceMove pmove1 = td.nodes[td.height - 1].curr_pmove;
+            const PieceMove pmove2 = td.nodes[td.height - offset - 1].curr_pmove;
+            if (pmove1 != PIECE_MOVE_NONE && pmove2 != PIECE_MOVE_NONE) {
+                adjustment += cont_corr_factor() * tables.cont_corr[cont_corr_idx(pmove1)][cont_corr_idx(pmove2)];
+            }
         }
-    }
+    };
+    adjust_cont(1);
 
     return adjustment / CORRHIST_GRAIN;
 }


### PR DESCRIPTION
#### STC
```
Elo   | 0.30 +- 2.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.20 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15006 W: 3582 L: 3569 D: 7855
Penta | [73, 1850, 3648, 1855, 77]
```
https://eduardomarinho.dev/test/668/
#### LTC
```
Elo   | 5.55 +- 3.70 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8082 W: 1857 L: 1728 D: 4497
Penta | [5, 876, 2155, 995, 10]
```
https://eduardomarinho.dev/test/669/


Bench: 6185314