### PR TITLE
Improve search shallower equation

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -460,8 +460,8 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             td.nodes[td.height - 1].reduction = 0;
 
             if (score > alpha && scaled_reduction > 1024) {
-                new_depth += score > best_score + lmr_deeper_margin() + lmr_deeper_factor() * new_depth;
-                new_depth -= score < best_score + new_depth + 1;
+                new_depth += score > best_score + lmr_deeper_margin() + lmr_deeper_depth_factor() * new_depth;
+                new_depth -= score < best_score + lmr_shallower_margin() + lmr_shallower_depth_factor() * new_depth;
 
                 score = -negamax(-alpha - 1, -alpha, new_depth, !cutnode, td);
             }

--- a/src/tune.h
+++ b/src/tune.h
@@ -151,7 +151,9 @@ TUNABLE_PARAM(lmr_counter_delta, 1387, 512, 2048, 128, 0.002)
 TUNABLE_PARAM(lmr_ttpv_delta, 1077, 512, 2048, 128, 0.002)
 TUNABLE_PARAM(lmr_corrhist_divisor, 414, 0, 2048, 128, 0.002)
 TUNABLE_PARAM(lmr_deeper_margin, 24, 20, 100, 5, 0.002)
-TUNABLE_PARAM(lmr_deeper_factor, 2, 1, 10, 1, 0.002)
+TUNABLE_PARAM(lmr_deeper_depth_factor, 2, 1, 10, 1, 0.002)
+TUNABLE_PARAM(lmr_shallower_margin, 10, 0, 40, 3, 0.002)
+TUNABLE_PARAM(lmr_shallower_depth_factor, 1, 0, 10, 1, 0.002)
 
 // Late Moves Pruning
 TUNABLE_PARAM(lmp_base, 126, 100, 200, 5, 0.002)


### PR DESCRIPTION
```
Elo   | 0.68 +- 1.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.55 (-2.94, 2.94) [0.00, 5.00]
Games | N: 50092 W: 12252 L: 12154 D: 25686
Penta | [278, 6001, 12389, 6101, 277]
```
https://eduardomarinho.dev/test/674/

Bench: 6015779