### PR TITLE
Increment qsearch move count after pruning heuristics

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -581,7 +581,6 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
             continue;
         }
         node.curr_pmove = {move, position.consult(move.from())};
-        ++moves_searched;
 
         if (best_score > -MATE_FOUND) {
             if (moves_searched >= 3) // late move pruning
@@ -596,6 +595,7 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
         position.make_move<true>(move);
         td.tt.prefetch(position.get_hash());
 
+        ++moves_searched;
         ++td.height;
         ScoreType score = -quiescence(-beta, -alpha, td);
         --td.height;


### PR DESCRIPTION
```
Elo   | 3.96 +- 2.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.07 (-2.25, 2.89) [0.00, 5.00]
Games | N: 15004 W: 3771 L: 3600 D: 7633
Penta | [74, 1732, 3726, 1889, 81]
```
https://eduardomarinho.dev/test/685/

Bench: 5479294