### PR TITLE
Finny table fused updates

### DIFF
--- a/src/eval/nnue/finny_table.cpp
+++ b/src/eval/nnue/finny_table.cpp
@@ -40,12 +40,13 @@ const PovAccumulator &FinnyTable::update(const Position &pos, const Color pov) {
         Bitboard added = pos.get_piece_bb(piece) & ~cached_entry.bbs[piece_idx];
         Bitboard removed = cached_entry.bbs[piece_idx] & ~pos.get_piece_bb(piece);
 
-        // TODO fused updates
-        // while (added && removed) {
-        //     const Square add0 = poplsb(added);
-        //     const Square sub0 = poplsb(removed);
-        //     cached_entry.pov_accumulator.self_add_sub(add0, sub0);
-        // }
+        // fused updates
+        while (added && removed) {
+            const Square add_sq = poplsb(added);
+            const Square sub_sq = poplsb(removed);
+            cached_entry.pov_accumulator.self_add_sub(feature_idx(piece, add_sq, king_sq, pov),
+                                                      feature_idx(piece, sub_sq, king_sq, pov));
+        }
 
         while (added) {
             const Square sq = poplsb(added);


### PR DESCRIPTION
```
Elo   | 2.39 +- 2.57 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 20512 W: 5280 L: 5139 D: 10093
Penta | [143, 2327, 5201, 2416, 169]
```
https://eduardomarinho.dev/test/667/

Bench: 5792628