### PR TITLE
Add 'to threatened' dimension to capture history

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -100,7 +100,7 @@ void History::update_capture_history_score(const Position &position, const Move 
     PieceType captured_pt = get_piece_type(position.consult(to));
     if (move.is_ep() || move.is_promotion())
         captured_pt = PAWN;
-    HistoryType *ptr = &m_capture_history[position.get_stm()][moved_pt][to][captured_pt];
+    HistoryType *ptr = &m_capture_history[position.get_stm()][moved_pt][to][captured_pt][position.is_threatened(to)];
     update_score(ptr, bonus);
 }
 

--- a/src/history.h
+++ b/src/history.h
@@ -46,7 +46,7 @@ class History {
         PieceType captured_pt = get_piece_type(position.consult(to));
         if (move.is_ep() || move.is_promotion())
             captured_pt = PAWN;
-        return m_capture_history[position.get_stm()][moved_pt][to][captured_pt];
+        return m_capture_history[position.get_stm()][moved_pt][to][captured_pt][position.is_threatened(to)];
     }
 
     inline void clear_killers(const int &height) {
@@ -86,7 +86,7 @@ class History {
             m_counter_moves[past_move.from_and_to()] = move;
     }
 
-    HistoryType m_capture_history[2][6][64][5];
+    HistoryType m_capture_history[2][6][64][5][2];
     HistoryType m_search_history_table[2][64 * 64][2][2];
     HistoryType m_continuation_history[12 * 64][12 * 64];
     Move m_counter_moves[64 * 64];


### PR DESCRIPTION
```
Elo   | 2.84 +- 2.22 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 3.08 (-2.25, 2.89) [0.00, 5.00]
Games | N: 22670 W: 5126 L: 4941 D: 12603
Penta | [19, 2550, 6017, 2725, 24]
```
https://eduardomarinho.dev/test/696/

Bench: 6468057