### PR TITLE
Change default net to 'minke33'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ elseif(UNIX)
 endif()
 
 # Define EVALFILE and make init.cpp recompiled when EVALFILE has changed
-set(EVALFILE "${CMAKE_SOURCE_DIR}/minke32.nnue")
+set(EVALFILE "${CMAKE_SOURCE_DIR}/minke33.nnue")
 target_compile_definitions(minke PRIVATE EVALFILE=\"${EVALFILE}\")
 set_property(
   SOURCE ${CMAKE_SOURCE_DIR}/src/init.cpp

--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@
 #   make EVALFILE=net.nnue bmi2                     # use a custom network file
 
 VERSION := 6.0.0
-DEFAULT_EVALFILE := minke32
+DEFAULT_EVALFILE := minke33
 
 PGO ?= off
 


### PR DESCRIPTION
Higher WDL for fine-tune stage (0.9)
#### Against minke32
##### Fixed nodes (25ksn)
```
Elo   : -1.64 +- 3.89                     
SPRT  : N=25000 Threads=1 Hash=64MB       
LLR   : -2.95 (-2.94, 2.94) [0.00, 5.00]  
Games : N: 14662 W: 4440 L: 4509 D: 5713  
Penta : [474, 1682, 3050, 1689, 436]      
```                
                      
##### STC (unfinished)                    
```
Elo   : 2.04 +- 2.64 (95%)                
SPRT  : 8.0+0.08s Threads=1 Hash=32MB     
LLR   : 1.04 (-2.25, 2.89) [0.00, 5.00]   
Games : N: 19068 W: 4625 L: 4513 D: 9930  
Penta : [110, 2250, 4690, 2386, 98]       
```
https://eduardomarinho.dev/test/704/      

##### LTC          
```
Elo   : 8.09 +- 4.68 (95%)                
SPRT  : 40.0+0.40s Threads=1 Hash=128MB   
LLR   : 2.95 (-2.25, 2.89) [0.00, 5.00]   
Games : N: 5066 W: 1193 L: 1075 D: 2798   
Penta : [4, 532, 1342, 652, 3]     
```       
https://eduardomarinho.dev/test/705/      


Bench: 6454197