### PR TITLE
refactor(move): modernize Move representation 

### DIFF
--- a/src/correction.cpp
+++ b/src/correction.cpp
@@ -48,7 +48,7 @@ void CorrectionHistory::update(const ThreadData& td, const int depth, const int 
             const PieceMove curr_pmove = td.nodes[td.height - 1].curr_pmove;
             const PieceMove past_pmove = td.nodes[td.height - offset - 1].curr_pmove;
 
-            if (curr_pmove != PIECE_MOVE_NONE && past_pmove != PIECE_MOVE_NONE) {
+            if (curr_pmove && past_pmove) {
                 tables.cont_corr[cont_corr_idx(curr_pmove)][cont_corr_idx(past_pmove)].update(bonus);
             }
         }
@@ -68,7 +68,7 @@ HistoryType CorrectionHistory::correction(const ThreadData& td) const {
         if (td.height >= offset + 1) {
             const PieceMove pmove1 = td.nodes[td.height - 1].curr_pmove;
             const PieceMove pmove2 = td.nodes[td.height - offset - 1].curr_pmove;
-            if (pmove1 != PIECE_MOVE_NONE && pmove2 != PIECE_MOVE_NONE) {
+            if (pmove1 && pmove2) {
                 adjustment += cont_corr_factor() * tables.cont_corr[cont_corr_idx(pmove1)][cont_corr_idx(pmove2)];
             }
         }

--- a/src/datagen/datagen.h
+++ b/src/datagen/datagen.h
@@ -129,7 +129,7 @@ class DatagenThread {
 
             Move move = m_td->best_move;
 
-            if (move == MOVE_NONE) {
+            if (!move) {
                 if (m_td->position.in_check())
                     result = m_td->position.get_stm() == WHITE ? LOSS : WIN;
                 else

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -47,9 +47,14 @@ void History::reset() {
     std::memset(m_capture_history, 0, sizeof(m_capture_history));
     std::memset(m_search_history_table, 0, sizeof(m_search_history_table));
     std::memset(m_continuation_history, 0, sizeof(m_continuation_history));
-    std::memset(m_killer_moves, MOVE_NONE.internal(), sizeof(m_killer_moves));
-    for (Move &move : m_counter_moves)
-        move = MOVE_NONE;
+
+    for (auto &moves : m_killer_moves) {
+        moves[0] = Move::none();
+        moves[1] = Move::none();
+    }
+    for (Move &move : m_counter_moves) {
+        move = Move::none();
+    }
 };
 
 HistoryType History::get_history(const ThreadData &td, const Move &move) const {
@@ -74,12 +79,12 @@ void History::update_history(const ThreadData &td, const Move &best_move, int de
 
         // Increase the score of the move that caused the beta cutoff
         update_history_heuristic_score(td.position, best_move, quiet_bonus);
-        update_continuation_history_table(td, quiets_tried.list[quiets_tried.size - 1], cont_bonus);
+        update_continuation_history_table(td, quiets_tried.back(), cont_bonus);
 
         // Decrease all the quiet moves scores that did not caused a beta cutoff
-        for (int idx = 0; idx < quiets_tried.size - 1; ++idx) {
-            update_history_heuristic_score(td.position, quiets_tried.list[idx].move, quiet_penalty);
-            update_continuation_history_table(td, quiets_tried.list[idx], cont_penalty);
+        for (size_t idx = 0; idx < quiets_tried.size() - 1; ++idx) {
+            update_history_heuristic_score(td.position, quiets_tried[idx].move, quiet_penalty);
+            update_continuation_history_table(td, quiets_tried[idx], cont_penalty);
         }
 
     } else {
@@ -87,8 +92,7 @@ void History::update_history(const ThreadData &td, const Move &best_move, int de
     }
 
     // Decrease all the noisy moves scores that did not caused a beta cutoff
-    for (int idx = 0; idx < tacticals_tried.size; ++idx) {
-        Move move = tacticals_tried.list[idx].move;
+    for (const auto [move, _] : tacticals_tried) {
         if (move != best_move)
             update_capture_history_score(td.position, move, capture_penalty);
     }
@@ -119,7 +123,7 @@ void History::update_continuation_history_table(const ThreadData &td, const Piec
 
 void History::update_continuation_history_score(const ThreadData &td, const PieceMove &pmove, int bonus, int offset) {
     int past_node_idx = td.height - offset;
-    if (past_node_idx >= 0 && td.nodes[past_node_idx].curr_pmove != PIECE_MOVE_NONE) {
+    if (past_node_idx >= 0 && td.nodes[past_node_idx].curr_pmove) {
         const size_t past_conthist_idx = cont_hist_idx(td.nodes[past_node_idx].curr_pmove);
         const size_t curr_conthist_idx = cont_hist_idx(pmove);
         HistoryType *ptr = &m_continuation_history[past_conthist_idx][curr_conthist_idx];
@@ -144,7 +148,7 @@ HistoryType History::get_continuation_history_score(const ThreadData &td, const 
 
 HistoryType History::get_continuation_history_entry(const ThreadData &td, const PieceMove &pmove, int offset) const {
     int past_node_idx = td.height - offset;
-    if (past_node_idx < 0 || td.nodes[past_node_idx].curr_pmove == PIECE_MOVE_NONE)
+    if (past_node_idx < 0 || !td.nodes[past_node_idx].curr_pmove)
         return 0;
 
     const size_t past_conthist_idx = cont_hist_idx(td.nodes[past_node_idx].curr_pmove);

--- a/src/history.h
+++ b/src/history.h
@@ -50,15 +50,14 @@ class History {
     }
 
     inline void clear_killers(const int &height) {
-        m_killer_moves[height][0] = MOVE_NONE;
-        m_killer_moves[height][1] = MOVE_NONE;
+        m_killer_moves[height][0] = Move::none();
+        m_killer_moves[height][1] = Move::none();
     }
     inline Move consult_killer1(const int &height) const { return m_killer_moves[height][0]; }
     inline Move consult_killer2(const int &height) const { return m_killer_moves[height][1]; }
     inline Move consult_counter(const Move &past_move) const {
-        // TODO try the usual indexing ([piece_type][to]), instead of butterfly
-        if (past_move == MOVE_NONE)
-            return MOVE_NONE;
+        if (!past_move)
+            return Move::none();
         return m_counter_moves[past_move.from_and_to()];
     }
     inline bool is_killer(const Move &move, const int &height) const {
@@ -82,7 +81,7 @@ class History {
     }
 
     inline void save_counter(const Move &past_move, const Move &move) {
-        if (past_move != MOVE_NONE)
+        if (past_move)
             m_counter_moves[past_move.from_and_to()] = move;
     }
 

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -21,7 +21,7 @@
 #include "types.h"
 #include "utils.h"
 
-std::string Move::get_algebraic_notation(const bool chess960, const Bitboard castle_rooks) const {
+std::string Move::to_uci(const bool chess960, const Bitboard castle_rooks) const {
     std::string algebraic_notation;
     Square source = from();
     Square target = to();

--- a/src/move.h
+++ b/src/move.h
@@ -24,90 +24,65 @@
 #include <string>
 
 #include "types.h"
+#include "utils.h"
 
 class Move {
   public:
-    // clang-format off
-    inline Move() : m_bytes(0) {};
-    inline Move(int16_t bytes) : m_bytes(bytes) {};
-    // clang-format on
-    inline Move(Square from, Square to, MoveType move_type) { m_bytes = (move_type << 12) | (to << 6) | (from); }
+    constexpr Move() : m_bytes(0) {}
+    constexpr Move(Square from, Square to, MoveType move_type) { m_bytes = (move_type << 12) | (to << 6) | (from); }
 
-    inline int from_and_to() const { return m_bytes & 0xFFF; }
-    inline Square from() const { return Square(m_bytes & 0x3F); }
-    inline Square to() const { return Square((m_bytes >> 6) & 0x3F); }
-    inline MoveType type() const { return MoveType((m_bytes >> 12) & 0xF); }
-    inline PieceType promotee() const {
+    static constexpr Move none() { return Move(); }
+
+    constexpr int from_and_to() const { return m_bytes & 0xFFF; }
+    constexpr Square from() const { return Square(m_bytes & 0x3F); }
+    constexpr Square to() const { return Square((m_bytes >> 6) & 0x3F); }
+    constexpr MoveType type() const { return MoveType((m_bytes >> 12) & 0xF); }
+    constexpr PieceType promotee() const {
         assert(is_promotion());
         return static_cast<PieceType>((type() & 0b0011) + 1);
     }
-    inline int16_t internal() const { return m_bytes; }
-    std::string get_algebraic_notation(const bool chess960, const Bitboard castle_rooks) const;
 
-    inline bool is_regular() const { return type() == REGULAR; }
-    inline bool is_castle() const { return type() == CASTLING; }
-    inline bool is_quiet() const { return is_regular() || is_castle(); }
-    inline bool is_capture() const { return type() & CAPTURE; }
-    inline bool is_promotion() const { return type() & PAWN_PROMOTION_MASK; }
-    inline bool is_ep() const { return type() == EP; }
-    inline bool is_noisy() const { return is_capture() || is_promotion(); }
+    std::string to_uci(bool chess960, Bitboard castle_rooks) const;
 
-    friend bool operator==(const Move& lhs, const Move& rhs);
-    friend bool operator==(const Move& lhs, const int& rhs);
+    constexpr bool is_regular() const { return type() == REGULAR; }
+    constexpr bool is_castle() const { return type() == CASTLING; }
+    constexpr bool is_quiet() const { return is_regular() || is_castle(); }
+    constexpr bool is_capture() const { return type() & CAPTURE; }
+    constexpr bool is_promotion() const { return type() & PAWN_PROMOTION_MASK; }
+    constexpr bool is_ep() const { return type() == EP; }
+    constexpr bool is_noisy() const { return is_capture() || is_promotion(); }
+    constexpr bool is_none() const { return m_bytes == 0; }
+    constexpr explicit operator bool() const { return !is_none(); }
+
+    constexpr bool operator==(const Move&) const = default;
 
   private:
     // Bits are arranged in the following way:
     // 4 bits for move type | 6 bits for target square | 6 bits for origin square
-    int16_t m_bytes;
+    uint16_t m_bytes;
 };
-const Move MOVE_NONE = Move();
 
 struct ScoredMove {
     Move move;
     int score;
-};
-inline bool operator==(const ScoredMove& lhs, const ScoredMove& rhs) {
-    return lhs.move == rhs.move && lhs.score == rhs.score;
-}
-const ScoredMove SCORED_MOVE_NONE = {MOVE_NONE, 0};
 
-struct MoveList {
-    Move moves[MAX_MOVES_PER_POS];
-    int size{0};
+    static constexpr ScoredMove none() { return {Move::none(), 0}; }
 
-    void clear() { size = 0; }
-
-    void push(Move move) {
-        assert(size < MAX_MOVES_PER_POS);
-        moves[size++] = move;
-    }
+    constexpr bool is_none() const { return move.is_none(); }
+    constexpr explicit operator bool() const { return !is_none(); }
 };
 
 struct PieceMove {
     Move move;
     Piece piece;
 
-    PieceMove() { PieceMove(MOVE_NONE, EMPTY); }
-    PieceMove(const Move& _move, const Piece& _piece) : move(_move), piece(_piece) {}
-};
-inline bool operator==(const PieceMove& lhs, const PieceMove& rhs) {
-    return lhs.move == rhs.move && lhs.piece == rhs.piece;
-}
-const PieceMove PIECE_MOVE_NONE = {MOVE_NONE, EMPTY};
+    static constexpr PieceMove none() { return {Move::none(), EMPTY}; }
 
-struct PieceMoveList {
-    PieceMove list[MAX_MOVES_PER_POS];
-    int size{0};
-
-    void clear() { size = 0; }
-
-    void push(const PieceMove& pt_move) {
-        assert(size < MAX_MOVES_PER_POS);
-        list[size++] = pt_move;
-    }
+    constexpr bool is_none() const { return move.is_none(); }
+    constexpr explicit operator bool() const { return !is_none(); }
 };
 
-inline bool operator==(const Move& lhs, const Move& rhs) { return lhs.internal() == rhs.internal(); }
-inline bool operator==(const Move& lhs, const int& rhs) { return lhs.internal() == rhs; }
+using MoveList = StaticVector<Move, MAX_MOVES_PER_POS>;
+using PieceMoveList = StaticVector<PieceMove, MAX_MOVES_PER_POS>;
 
 #endif // #ifndef MOVE_H

--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -37,7 +37,7 @@ void MovePicker::init(Move ttmove, ThreadData &td, MovePickerType mp_type, Score
     m_threshold = threshold;
     m_move_list.clear();
 
-    if (ttmove != MOVE_NONE)
+    if (ttmove)
         m_stage = PICK_TT;
     else
         m_stage = GEN_NOISY;
@@ -45,32 +45,30 @@ void MovePicker::init(Move ttmove, ThreadData &td, MovePickerType mp_type, Score
     m_killer1 = m_td->search_history.consult_killer1(m_td->height);
     m_killer2 = m_td->search_history.consult_killer2(m_td->height);
 
-    m_counter = MOVE_NONE;
+    m_counter = Move::none();
     if (m_td->height > 0)
         m_counter = m_td->search_history.consult_counter(m_td->nodes[m_td->height - 1].curr_pmove.move);
     if (m_counter == m_killer1 || m_counter == m_killer2)
-        m_counter = MOVE_NONE;
+        m_counter = Move::none();
 
     m_idx = m_end = m_bad_noisy_end = 0;
 }
 
-Move MovePicker::next_move(const bool skip_quiets) { return next_move_scored(skip_quiets).move; }
-
-ScoredMove MovePicker::next_move_scored(const bool skip_quiets) {
+Move MovePicker::next_move(bool skip_quiets) {
     switch (m_stage) {
         case PICK_TT:
             m_stage = GEN_NOISY;
             if ((!skip_quiets || m_ttmove.is_noisy()) && m_td->position.is_pseudo_legal(m_ttmove)) {
-                return {m_ttmove, 0};
+                return m_ttmove;
             } else {
             }
-            // Fall-through
+            [[fallthrough]];
         case GEN_NOISY:
             Movegen::noisies(m_move_list, m_td->position);
             m_end = m_move_list.size();
             score_noisy_moves();
             m_stage = PICK_GOOD_NOISY;
-            // Fall-through
+            [[fallthrough]];
         case PICK_GOOD_NOISY:
             while (m_idx != m_end) {
                 const size_t idx = sort_next_move();
@@ -82,49 +80,49 @@ ScoredMove MovePicker::next_move_scored(const bool skip_quiets) {
                 if (!SEE(m_td->position, move, see_threshold)) // Bad noisy
                     m_move_list[m_bad_noisy_end++] = m_move_list[idx];
                 else if (move != m_ttmove)
-                    return {move, score};
+                    return move;
             }
             if ((m_mp_type == QSEARCH && skip_quiets) || m_mp_type == PROBCUT) {
                 m_stage = FINISHED;
-                return SCORED_MOVE_NONE;
+                return Move::none();
             } else if (skip_quiets) {
                 m_idx = 0;
                 m_stage = PICK_BAD_NOISY;
-                return next_move_scored(skip_quiets); // Work around to avoid the switch fall-through
+                return next_move(skip_quiets); // Work around to avoid the switch fall-through
             } else {
                 m_idx = m_bad_noisy_end;
                 m_move_list.resize(m_bad_noisy_end);
                 m_stage = GEN_QUIET;
             }
-            // Fall-through
+            [[fallthrough]];
         case GEN_QUIET:
             Movegen::quiets(m_move_list, m_td->position);
             m_end = m_move_list.size();
             score_quiet_moves();
             m_stage = PICK_QUIET;
-            // Fall-through
+            [[fallthrough]];
         case PICK_QUIET:
             while (m_idx != m_end && !skip_quiets) {
                 size_t idx = sort_next_move();
                 const auto [move, score] = m_move_list[idx];
 
                 if (move != m_ttmove)
-                    return {move, score};
+                    return move;
             }
             m_idx = 0;
             m_stage = PICK_BAD_NOISY;
-            // Fall-through
+            [[fallthrough]];
         case PICK_BAD_NOISY:
             while (m_idx != m_bad_noisy_end) {
                 // No need to call 'sort_next_move', since bad noisy moves are already sorted in PickGoodNoisy
                 const auto [move, score] = m_move_list[m_idx++];
                 if (move != m_ttmove)
-                    return {move, score};
+                    return move;
             }
             m_stage = FINISHED;
-            // Fall-through
+            [[fallthrough]];
         case FINISHED:
-            return SCORED_MOVE_NONE;
+            return Move::none();
         default:
             __builtin_unreachable();
     }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -785,7 +785,7 @@ bool Position::is_legal(const Move &move) {
 
 // TODO if the moved piece and/or the capture piece is present in the move itself this could be way faster
 bool Position::is_pseudo_legal(const Move &move) const {
-    if (move == MOVE_NONE)
+    if (!move)
         return false;
 
     Square from = move.from();

--- a/src/pv_list.cpp
+++ b/src/pv_list.cpp
@@ -29,7 +29,7 @@ void PvList::update(Move new_move, const PvList &list) {
 
 void PvList::print(const bool chess960, const Bitboard castle_rooks) const {
     for (int i = 0; i < m_size; ++i) {
-        std::cout << m_pv[i].get_algebraic_notation(chess960, castle_rooks) << ' ';
+        std::cout << m_pv[i].to_uci(chess960, castle_rooks) << ' ';
     }
 }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -79,7 +79,7 @@ ThreadData::ThreadData() {
 }
 
 void ThreadData::reset_search_parameters() {
-    best_move = MOVE_NONE;
+    best_move = Move::none();
     stop = true;
     height = 0;
     nodes_searched = -1; // Avoid counting the root
@@ -100,7 +100,7 @@ inline bool stop_search(const ThreadData &td) {
 ScoreType iterative_deepening(ThreadData &td) {
     td.stop = false;
 
-    Move best_move = MOVE_NONE;
+    Move best_move = Move::none();
     ScoreType past_eval = -MAX_SCORE;
     for (CounterType depth = 1; depth <= std::min(td.search_limits.depth, MAX_SEARCH_DEPTH - 1); ++depth) {
         ScoreType eval = aspiration(depth, past_eval, td);
@@ -109,7 +109,7 @@ ScoreType iterative_deepening(ThreadData &td) {
 
         best_move = td.best_move;
         past_eval = eval;
-        if (best_move == MOVE_NONE) // No legal moves
+        if (!best_move) // No legal moves
             break;
 
         if (td.report)
@@ -125,10 +125,7 @@ ScoreType iterative_deepening(ThreadData &td) {
 
     if (td.report)
         std::cout << "bestmove "
-                  << (best_move == MOVE_NONE
-                          ? "none"
-                          : best_move.get_algebraic_notation(td.chess960, td.position.get_castle_rooks()))
-                  << std::endl;
+                  << (!best_move ? "none" : best_move.to_uci(td.chess960, td.position.get_castle_rooks())) << std::endl;
 
     td.stop = true;
     td.best_move = best_move; // A partial search would mess this up
@@ -179,8 +176,9 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
         return quiescence(alpha, beta, td);
     ++td.nodes_searched;
 
-    bool pv_node = alpha != beta - 1;
-    bool singular_search = td.nodes[td.height].excluded_move != MOVE_NONE;
+    const bool pv_node = alpha != beta - 1;
+    const Move excluded_move = td.nodes[td.height].excluded_move;
+    const bool singular_search = !excluded_move.is_none();
     Position &position = td.position;
     NodeData &node = td.nodes[td.height];
 
@@ -205,7 +203,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
     bool tthit = td.tt.probe(position, tte);
     tthit = tthit && !singular_search; // Don't use ttentry result if in singular search
     // Extraction data from ttentry if tthit
-    Move ttmove = (tthit ? tte.best_move() : MOVE_NONE);
+    Move ttmove = (tthit ? tte.best_move() : Move::none());
     ScoreType ttscore = tthit ? tte.score() : SCORE_NONE;
     ScoreType tteval = tthit ? tte.eval() : SCORE_NONE;
     IndexType ttbound = tthit ? tte.bound() : static_cast<IndexType>(BOUND_EMPTY);
@@ -238,11 +236,11 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
     } else {
         raw_eval = position.eval();
         eval = node.static_eval = adjust_eval(position, raw_eval, correction_value);
-        td.tt.store(position.get_hash(), 0, MOVE_NONE, SCORE_NONE, raw_eval, BOUND_EMPTY, ttpv, td.tt.age());
+        td.tt.store(position.get_hash(), 0, Move::none(), SCORE_NONE, raw_eval, BOUND_EMPTY, ttpv, td.tt.age());
     }
 
     // Clean killer moves for the next ply
-    td.nodes[td.height + 1].excluded_move = MOVE_NONE;
+    td.nodes[td.height + 1].excluded_move = Move::none();
     td.search_history.clear_killers(td.height + 1);
 
     bool improving = [&]() -> bool {
@@ -298,7 +296,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             position.make_null_move();
             td.tt.prefetch(position.get_hash());
             ++td.height;
-            node.curr_pmove = PIECE_MOVE_NONE;
+            node.curr_pmove = PieceMove::none();
             ScoreType null_score = -negamax(-beta, -beta + 1, depth - reduction, !cutnode, td);
             position.unmake_null_move();
             --td.height;
@@ -312,9 +310,13 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
         if (depth >= probcut_min_depth() && std::abs(beta) < MATE_FOUND &&
             (!tthit || ttdepth < depth - 3 || (ttscore != SCORE_NONE && ttscore >= pc_beta))) {
             MovePicker move_picker(ttmove, td, PROBCUT, pc_beta - node.static_eval);
-            Move move;
-            while ((move = move_picker.next_move(true)) != MOVE_NONE) {
-                if (move == td.nodes[td.height].excluded_move || !position.is_legal(move)) { // Avoid illegal moves
+            while (true) { // iterate through all moves in move_picker
+                const Move move = move_picker.next_move(true);
+                if (!move) {
+                    break;
+                }
+
+                if (move == excluded_move || !position.is_legal(move)) { // Avoid excluded or illegal moves
                     continue;
                 }
 
@@ -340,8 +342,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
         }
     }
 
-    Move move = MOVE_NONE;
-    Move best_move = MOVE_NONE;
+    Move best_move = Move::none();
     ScoreType best_score = -MAX_SCORE;
     ScoreType old_alpha = alpha;
     int moves_searched = 0;
@@ -349,10 +350,12 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
     bool skip_quiets = false;
     MovePicker move_picker(ttmove, td, SEARCH);
     PieceMoveList quiets_tried, tacticals_tried;
-    while ((move = move_picker.next_move(skip_quiets)) != MOVE_NONE) {
-        if (move == td.nodes[td.height].excluded_move) // Skip excluded moves
-            continue;
-        if (!position.is_legal(move)) { // Avoid illegal moves
+    while (true) { // iterate through all moves in move_picker
+        const Move move = move_picker.next_move(skip_quiets);
+        if (!move) {
+            break;
+        }
+        if (move == excluded_move || !position.is_legal(move)) { // Skip excluded and illegal moves
             continue;
         }
 
@@ -392,7 +395,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
         // Extensions
         int extension = 0;
         if (!root && depth >= singular_extension_min_depth() && move == ttmove && ttdepth > depth - 4 &&
-            move != td.nodes[td.height].excluded_move && ttbound == LOWER) {
+            move != excluded_move && ttbound == LOWER) {
             ScoreType singular_beta = ttscore - depth * singular_extension_depth_factor() / 16;
             ScoreType singular_depth = (depth - 1) / 2;
 
@@ -400,7 +403,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
             td.nodes[td.height].excluded_move = ttmove;
             ScoreType singular_score = negamax(singular_beta - 1, singular_beta, singular_depth, cutnode, td);
-            td.nodes[td.height].excluded_move = MOVE_NONE;
+            td.nodes[td.height].excluded_move = Move::none();
 
             if (singular_score < singular_beta) {
                 extension = 1;
@@ -509,7 +512,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
     }
 
     const BoundType bound = best_score >= beta ? LOWER : (alpha != old_alpha ? EXACT : UPPER);
-    if (!in_check && (best_move == MOVE_NONE || best_move.is_quiet()) &&
+    if (!in_check && (best_move.is_none() || best_move.is_quiet()) &&
         (bound == EXACT || (bound == LOWER && best_score > node.static_eval) ||
          (bound == UPPER && best_score < node.static_eval))) {
         td.correction_history.update(td, depth, best_score - node.static_eval);
@@ -537,7 +540,7 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
     NodeData &node = td.nodes[td.height];
     TTEntry tte;
     bool tthit = td.tt.probe(position, tte);
-    Move ttmove = tthit ? tte.best_move() : MOVE_NONE;
+    Move ttmove = tthit ? tte.best_move() : Move::none();
     ScoreType ttscore = tthit ? tte.score() : SCORE_NONE;
     ScoreType tteval = tthit ? tte.eval() : SCORE_NONE;
     IndexType ttbound = tthit ? tte.bound() : static_cast<IndexType>(BOUND_EMPTY);
@@ -564,7 +567,7 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
     } else {
         raw_eval = position.eval();
         best_score = node.static_eval = adjust_eval(position, raw_eval, td.correction_history.correction(td));
-        td.tt.store(position.get_hash(), 0, MOVE_NONE, SCORE_NONE, raw_eval, BOUND_EMPTY, ttpv, td.tt.age());
+        td.tt.store(position.get_hash(), 0, Move::none(), SCORE_NONE, raw_eval, BOUND_EMPTY, ttpv, td.tt.age());
     }
 
     // Stand-pat
@@ -572,11 +575,14 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
         return best_score;
     alpha = std::max(alpha, best_score);
 
-    Move move = MOVE_NONE;
-    Move best_move = MOVE_NONE;
-    MovePicker move_picker((tthit ? ttmove : MOVE_NONE), td, QSEARCH);
+    Move best_move = Move::none();
+    MovePicker move_picker((tthit ? ttmove : Move::none()), td, QSEARCH);
     int moves_searched = 0;
-    while ((move = move_picker.next_move(!in_check)) != MOVE_NONE) {
+    while (true) { // iterate through all moves in move_picker
+        const Move move = move_picker.next_move(!in_check);
+        if (!move) {
+            break;
+        }
         if (!position.is_legal(move)) { // Avoid illegal moves
             continue;
         }

--- a/src/search.h
+++ b/src/search.h
@@ -52,8 +52,8 @@ struct NodeData {
     PvList pv_list;
 
     inline void reset() {
-        curr_pmove = PIECE_MOVE_NONE;
-        excluded_move = MOVE_NONE;
+        curr_pmove = PieceMove::none();
+        excluded_move = Move::none();
         static_eval = SCORE_NONE;
         pv_list.clear();
     }

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -32,7 +32,7 @@ inline static KeyType key_from_hash(const HashType &hash) { return static_cast<K
 void TTEntry::store(const HashType &hash, const IndexType &depth, const Move &best_move, const ScoreType &score,
                     const ScoreType &eval, const BoundType &bound, const bool was_pv, const IndexType age,
                     const bool &tthit) {
-    if (best_move != MOVE_NONE || !tthit)
+    if (best_move || !tthit)
         m_best_move = best_move;
 
     if (!tthit || bound == EXACT || depth + 4 + 2 * was_pv > m_depth || age != this->age()) {
@@ -47,7 +47,7 @@ void TTEntry::store(const HashType &hash, const IndexType &depth, const Move &be
 void TTEntry::reset() {
     m_key = 0;
     m_depth = 0;
-    m_best_move = MOVE_NONE;
+    m_best_move = Move::none();
     m_score = SCORE_NONE;
     m_eval = SCORE_NONE;
     m_age_pv_bound = 0;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -139,11 +139,10 @@ void UCI::print_debug_info() {
     m_td->position.print();
     TTEntry tte;
     bool tthit = m_td->tt.probe(m_td->position, tte);
-    Move ttmove = MOVE_NONE;
+    Move ttmove = Move::none();
     if (tthit) {
         ttmove = tte.best_move();
-        std::cout << "Best move: " << ttmove.get_algebraic_notation(m_td->chess960, m_td->position.get_castle_rooks())
-                  << std::endl;
+        std::cout << "Best move: " << ttmove.to_uci(m_td->chess960, m_td->position.get_castle_rooks()) << std::endl;
     }
     Movegen::ScoredMoveList move_list;
     Movegen::all(move_list, m_td->position);
@@ -151,7 +150,7 @@ void UCI::print_debug_info() {
     for (ScoredMove scored_move : move_list) {
         if (!m_td->position.is_legal(scored_move.move))
             std::cout << "*";
-        std::cout << scored_move.move.get_algebraic_notation(m_td->chess960, m_td->position.get_castle_rooks()) << "("
+        std::cout << scored_move.move.to_uci(m_td->chess960, m_td->position.get_castle_rooks()) << "("
                   << scored_move.score << ") ";
     }
     std::cout << "\nNNUE eval: " << m_td->position.eval() << std::endl;
@@ -192,8 +191,7 @@ void UCI::set_position(const std::string &fen, const std::vector<std::string> &m
         Movegen::all(move_list, m_td->position);
 
         for (auto scored_move : move_list) {
-            if (moves[index] ==
-                scored_move.move.get_algebraic_notation(m_td->chess960, m_td->position.get_castle_rooks())) {
+            if (moves[index] == scored_move.move.to_uci(m_td->chess960, m_td->position.get_castle_rooks())) {
                 m_td->position.make_move<false>(scored_move.move);
                 break;
             }
@@ -299,8 +297,7 @@ int64_t UCI::perft(Position &position, CounterType depth, bool root) {
         position.unmake_move<false>(move);
 
         if (root)
-            std::cout << move.get_algebraic_notation(m_td->chess960, m_td->position.get_castle_rooks()) << ": " << count
-                      << std::endl;
+            std::cout << move.to_uci(m_td->chess960, m_td->position.get_castle_rooks()) << ": " << count << std::endl;
     }
 
     if (root)

--- a/src/utils.h
+++ b/src/utils.h
@@ -254,6 +254,12 @@ class StaticVector {
     [[nodiscard]] inline auto begin() const { return m_array.begin(); }
     [[nodiscard]] inline auto end() const { return m_array.begin() + static_cast<std::ptrdiff_t>(m_size); }
 
+    [[nodiscard]] inline T front() const { return m_array[0]; }
+    [[nodiscard]] inline T back() const {
+        assert(m_size > 0);
+        return m_array[m_size - 1];
+    }
+
   private:
     std::array<T, MAX_SIZE> m_array;
     size_t m_size{};


### PR DESCRIPTION
```
Elo   | 3.68 +- 3.61 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 3.04 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 10372 W: 2676 L: 2566 D: 5130
Penta | [71, 1149, 2656, 1219, 91]
```
https://eduardomarinho.dev/test/716/

Bench: 6454197