### PR TITLE
feat(search): scale RFP margin by position complexity

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -222,6 +222,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
     bool in_check = position.in_check();
     ScoreType eval, raw_eval;
     ScoreType correction_value = td.correction_history.correction(td);
+    ScoreType complexity = std::abs(correction_value);
     if (in_check) {
         eval = node.static_eval = raw_eval = SCORE_NONE;
     } else if (singular_search) {
@@ -269,8 +270,16 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
         }
 
         // Reverse futility pruning
-        if (depth < rfp_max_depth() && eval - rfp_margin() * (depth - improving) >= beta)
+        const ScoreType rfp_margin = [&]() {
+            ScoreType rfp_margin = 0;
+            rfp_margin += rfp_depth_factor() * depth;
+            rfp_margin += rfp_improving_margin() * improving;
+            rfp_margin += rfp_complexity_factor() * complexity / 1024;
+            return rfp_margin;
+        }();
+        if (depth < rfp_max_depth() && eval - rfp_margin >= beta) {
             return eval;
+        }
 
         // Razoring heuristic
         if (depth <= razoring_max_depth() && node.static_eval + razoring_mult() * depth < alpha) {
@@ -461,7 +470,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                 scaled_reduction -= ttpv * lmr_ttpv_delta();
 
                 // Reduce based on correction history.
-                scaled_reduction -= std::abs(correction_value) / lmr_corrhist_divisor();
+                scaled_reduction -= complexity / lmr_corrhist_divisor();
             } else {
                 // reduce noisy
             }

--- a/src/uci/tune.h
+++ b/src/uci/tune.h
@@ -139,7 +139,9 @@ FIXED_PARAM(nmp_min_depth, 2, 2, 8, 0.5, 0.002)
 TUNABLE_PARAM(hindsight_eval, 150, 50, 300, 10, 0.002)
 
 // Reverse Futility Pruning
-TUNABLE_PARAM(rfp_margin, 106, 50, 150, 5, 0.002)
+TUNABLE_PARAM(rfp_depth_factor, 106, 50, 150, 5, 0.002)
+TUNABLE_PARAM(rfp_improving_margin, -106, -50, -150, 5, 0.002)
+TUNABLE_PARAM(rfp_complexity_factor, 250, 100, 400, 15, 0.002)
 FIXED_PARAM(rfp_max_depth, 10, 5, 15, 0.5, 0.002)
 
 // Late Move Reductions


### PR DESCRIPTION
```
Elo   | 2.63 +- 2.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.07 (-2.25, 2.89) [0.00, 5.00]
Games | N: 29580 W: 7110 L: 6886 D: 15584
Penta | [100, 3551, 7284, 3735, 120]
```
https://eduardomarinho.dev/test/726/

Bench: 5999990