### PR TITLE
fix(search): properly access continuation correction

### DIFF
--- a/src/search/correction.cpp
+++ b/src/search/correction.cpp
@@ -27,7 +27,7 @@
 #include "uci/tune.h"
 
 static inline size_t cont_corr_idx(const PieceMove& pmove) {
-    return (static_cast<size_t>(get_piece_type(pmove.piece)) << 6) | static_cast<size_t>(pmove.move.to());
+    return (static_cast<size_t>(pmove.piece) << 6) | static_cast<size_t>(pmove.move.to());
 };
 
 void CorrectionHistory::reset() {
@@ -49,7 +49,7 @@ void CorrectionHistory::update(const ThreadData& td, const int depth, const int 
             const PieceMove past_pmove = td.nodes[td.height - offset - 1].curr_pmove;
 
             if (curr_pmove && past_pmove) {
-                tables.cont_corr[cont_corr_idx(curr_pmove)][cont_corr_idx(past_pmove)].update(bonus);
+                m_cont_corr[cont_corr_idx(curr_pmove)][cont_corr_idx(past_pmove)].update(bonus);
             }
         }
     };
@@ -69,7 +69,7 @@ HistoryType CorrectionHistory::correction(const ThreadData& td) const {
             const PieceMove pmove1 = td.nodes[td.height - 1].curr_pmove;
             const PieceMove pmove2 = td.nodes[td.height - offset - 1].curr_pmove;
             if (pmove1 && pmove2) {
-                adjustment += cont_corr_factor() * tables.cont_corr[cont_corr_idx(pmove1)][cont_corr_idx(pmove2)];
+                adjustment += cont_corr_factor() * m_cont_corr[cont_corr_idx(pmove1)][cont_corr_idx(pmove2)];
             }
         }
     };

--- a/src/search/correction.h
+++ b/src/search/correction.h
@@ -52,8 +52,8 @@ class CorrectionHistory {
         std::array<CorrectionEntry, CORRHIST_SIZE> pawn{};
         std::array<CorrectionEntry, CORRHIST_SIZE> white_nonpawn{};
         std::array<CorrectionEntry, CORRHIST_SIZE> black_nonpawn{};
-        std::array<std::array<CorrectionEntry, 64 * 6>, 64 * 6> cont_corr{};
     };
 
     std::array<PovTables, 2> m_pov_tables;
+    std::array<std::array<CorrectionEntry, 64 * 12>, 64 * 12> m_cont_corr{};
 };


### PR DESCRIPTION
```
Elo   | 1.50 +- 3.03 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 3.23 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 14814 W: 3685 L: 3621 D: 7508
Penta | [88, 1787, 3598, 1841, 93]
```
https://eduardomarinho.dev/test/730/

Bench: 5920736