### PR TITLE
fix(search): correctly access capture history for capture promotions

### DIFF
--- a/src/search/history.cpp
+++ b/src/search/history.cpp
@@ -102,7 +102,7 @@ void History::update_capture_history_score(const Position &position, const Move 
     Square to = move.to();
     PieceType moved_pt = get_piece_type(position.consult(move.from()));
     PieceType captured_pt = get_piece_type(position.consult(to));
-    if (move.is_ep() || move.is_promotion())
+    if (captured_pt == NONE)
         captured_pt = PAWN;
     HistoryType *ptr = &m_capture_history[position.get_stm()][moved_pt][to][captured_pt][position.is_threatened(to)];
     update_score(ptr, bonus);

--- a/src/search/history.h
+++ b/src/search/history.h
@@ -43,7 +43,7 @@ class History {
         Square to = move.to();
         PieceType moved_pt = get_piece_type(position.consult(move.from()));
         PieceType captured_pt = get_piece_type(position.consult(to));
-        if (move.is_ep() || move.is_promotion())
+        if (captured_pt == NONE)
             captured_pt = PAWN;
         return m_capture_history[position.get_stm()][moved_pt][to][captured_pt][position.is_threatened(to)];
     }


### PR DESCRIPTION
```
Elo   | 0.52 +- 2.58 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 20852 W: 5382 L: 5351 D: 10119
Penta | [185, 2384, 5246, 2437, 174]
```
https://eduardomarinho.dev/test/727/

Bench: 5920747