### PR TITLE
perf(search): reduce number of syscalls by checking time passed less

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -94,7 +94,8 @@ void ThreadData::reset_search_parameters() {
 void ThreadData::set_search_limits(const SearchLimits sl) { this->search_limits = sl; }
 
 inline bool stop_search(const ThreadData &td) {
-    return td.time_manager.time_over() || td.stop || td.nodes_searched > td.search_limits.maximum_node;
+    return ((td.nodes_searched & 2047) == 2047 && td.time_manager.time_over()) || td.stop ||
+           td.nodes_searched > td.search_limits.maximum_node;
 }
 
 ScoreType iterative_deepening(ThreadData &td) {


### PR DESCRIPTION
```
Elo   | 8.93 +- 6.30 (95%)
SPRT  | 2.0+0.02s Threads=1 Hash=32MB
LLR   | 3.05 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 4240 W: 1190 L: 1081 D: 1969
Penta | [50, 493, 946, 560, 71]
```
https://eduardomarinho.dev/test/743/

quick sanity check

Bench: 5920747