### PR TITLE
feat(search): improve node scaling time manager params and fix related bug

### DIFF
--- a/src/search/time_manager.cpp
+++ b/src/search/time_manager.cpp
@@ -54,7 +54,7 @@ void TimeManager::reset(CounterType inc, CounterType time, CounterType mtg, Coun
     TimeType max_time = 0.8 * time;
     m_optimum_time = std::min(m_optimum_time, max_time);
     m_maximum_time = std::min(m_maximum_time, max_time);
-    m_scale = 1.63;
+    m_optimum_time *= 1.63;
 }
 
 void TimeManager::reset() {
@@ -69,9 +69,9 @@ void TimeManager::update(const ThreadData &td) {
     if (m_movetime || !m_time_set)
         return;
 
-    // const double node_fraction = td.node_table[td.best_move.from_and_to()] / static_cast<double>(td.nodes_searched);
-    // const double node_scaling_factor = (node_tm_base() / 100.0 - node_fraction) * (node_tm_scale() / 100.0);
-    // m_scale = std::clamp<double>(node_scaling_factor, tm_min_scale() / 100.0, tm_max_scale() / 100.0);
+    const double node_fraction = td.node_table[td.best_move.from_and_to()] / static_cast<double>(td.nodes_searched);
+    const double node_scaling_factor = (node_tm_base() / 100.0 - node_fraction) * (node_tm_scale() / 100.0);
+    m_scale = std::clamp<double>(node_scaling_factor, tm_min_scale() / 100.0, tm_max_scale() / 100.0);
 }
 
 bool TimeManager::stop_early() const { return m_can_stop && time_passed() > m_optimum_time * m_scale; }

--- a/src/search/time_manager.cpp
+++ b/src/search/time_manager.cpp
@@ -54,6 +54,7 @@ void TimeManager::reset(CounterType inc, CounterType time, CounterType mtg, Coun
     TimeType max_time = 0.8 * time;
     m_optimum_time = std::min(m_optimum_time, max_time);
     m_maximum_time = std::min(m_maximum_time, max_time);
+    m_scale = 1.63;
 }
 
 void TimeManager::reset() {
@@ -68,9 +69,9 @@ void TimeManager::update(const ThreadData &td) {
     if (m_movetime || !m_time_set)
         return;
 
-    const double node_fraction = td.node_table[td.best_move.from_and_to()] / static_cast<double>(td.nodes_searched);
-    const double node_scaling_factor = (node_tm_base() / 100.0 - node_fraction) * (node_tm_scale() / 100.0);
-    m_scale = std::clamp<double>(node_scaling_factor, tm_min_scale() / 100.0, tm_max_scale() / 100.0);
+    // const double node_fraction = td.node_table[td.best_move.from_and_to()] / static_cast<double>(td.nodes_searched);
+    // const double node_scaling_factor = (node_tm_base() / 100.0 - node_fraction) * (node_tm_scale() / 100.0);
+    // m_scale = std::clamp<double>(node_scaling_factor, tm_min_scale() / 100.0, tm_max_scale() / 100.0);
 }
 
 bool TimeManager::stop_early() const { return m_can_stop && time_passed() > m_optimum_time * m_scale; }

--- a/src/uci/tune.h
+++ b/src/uci/tune.h
@@ -228,10 +228,10 @@ TUNABLE_PARAM(conthist_2ply_weight, 1144, 0, 1536, 50, 0.002)
 TUNABLE_PARAM(conthist_4ply_weight, 559, 0, 1536, 50, 0.002)
 
 // Time Manager
-TUNABLE_PARAM(node_tm_base, 209, 150, 300, 5, 0.002)
-TUNABLE_PARAM(node_tm_scale, 161, 100, 250, 5, 0.002)
-TUNABLE_PARAM(tm_min_scale, 32, 10, 100, 5, 0.002)
-TUNABLE_PARAM(tm_max_scale, 163, 100, 250, 5, 0.002)
+TUNABLE_PARAM(node_tm_base, 150, 100, 200, 5, 0.002)
+TUNABLE_PARAM(node_tm_scale, 160, 100, 300, 5, 0.002)
+TUNABLE_PARAM(tm_min_scale, 50, 10, 100, 5, 0.002)
+TUNABLE_PARAM(tm_max_scale, 250, 150, 350, 5, 0.002)
 
 // Material scale
 TUNABLE_PARAM(pawn_scaling_factor, 98, 20, 160, 5, 0.002)


### PR DESCRIPTION
### STC
```
Elo   | 6.69 +- 4.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6856 W: 1685 L: 1553 D: 3618
Penta | [28, 761, 1727, 875, 37]
```
https://eduardomarinho.dev/test/762/

### LTC
```
Elo   | 8.47 +- 4.80 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4840 W: 1146 L: 1028 D: 2666
Penta | [0, 519, 1270, 625, 6]
```
https://eduardomarinho.dev/test/763/

Bench: 5920747