### PR TITLE
feat(search): simplify timeman equations and make params tunable

### DIFF
--- a/src/search/time_manager.cpp
+++ b/src/search/time_manager.cpp
@@ -41,20 +41,15 @@ void TimeManager::reset(CounterType inc, CounterType time, CounterType mtg, Coun
         return;
     }
 
-    time = std::min(time - overhead, time / 2); // Decrease the overhead on total time
-    time = std::max(time, 1);                   // Ensure time is positive
-    inc = std::max(inc, 0);                     // Ensure inc is non negative
-    mtg = (mtg > 0 ? std::min(mtg, 50) : 50);   // Ensure movestogo is at most 50 if positive, else set it to 50
+    const TimeType limit = std::max(std::max(time - overhead, time / 2),
+                                    1);       // Decrease the overhead from total time and ensure limit its positive
+    inc = std::max(inc, 0);                   // Ensure inc is non negative
+    mtg = (mtg > 0 ? mtg : tm_default_mtg()); // set mtg to default if invalid, i.e. if non-positive
 
-    double base_time = 0.8 * time / static_cast<double>(mtg) + inc;
-    m_optimum_time = base_time;
-    m_maximum_time = 4 * base_time;
+    const double base_time = limit / static_cast<double>(mtg) + inc * tm_increment_factor() / 100.0;
 
-    // Limit time usage to 80% of total game time
-    TimeType max_time = 0.8 * time;
-    m_optimum_time = std::min(m_optimum_time, max_time);
-    m_maximum_time = std::min(m_maximum_time, max_time);
-    m_optimum_time *= 1.63;
+    m_maximum_time = limit * tm_max_time_factor() / 100.0;
+    m_optimum_time = std::min<TimeType>(base_time * tm_opt_time_factor() / 100.0, m_maximum_time);
 }
 
 void TimeManager::reset() {

--- a/src/uci/tune.h
+++ b/src/uci/tune.h
@@ -228,6 +228,11 @@ TUNABLE_PARAM(conthist_2ply_weight, 1144, 0, 1536, 50, 0.002)
 TUNABLE_PARAM(conthist_4ply_weight, 559, 0, 1536, 50, 0.002)
 
 // Time Manager
+TUNABLE_PARAM(tm_default_mtg, 30, 10, 60, 1, 0.002)
+TUNABLE_PARAM(tm_increment_factor, 75, 20, 120, 5, 0.002)
+TUNABLE_PARAM(tm_opt_time_factor, 75, 20, 100, 5, 0.002)
+TUNABLE_PARAM(tm_max_time_factor, 75, 20, 100, 5, 0.002)
+
 TUNABLE_PARAM(node_tm_base, 150, 100, 200, 5, 0.002)
 TUNABLE_PARAM(node_tm_scale, 160, 100, 300, 5, 0.002)
 TUNABLE_PARAM(tm_min_scale, 50, 10, 100, 5, 0.002)


### PR DESCRIPTION
### STC
```
Elo   | 5.62 +- 4.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 7168 W: 1776 L: 1660 D: 3732
Penta | [26, 815, 1800, 903, 40]
```
https://eduardomarinho.dev/test/766/

### LTC
```
Elo   | 8.48 +- 5.45 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 3.08 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 3772 W: 928 L: 836 D: 2008
Penta | [1, 405, 984, 493, 3]
```
https://eduardomarinho.dev/test/768/

Bench: 5920747