### PR TITLE
feat(search): time management based on pv stability

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -103,10 +103,17 @@ ScoreType iterative_deepening(ThreadData &td) {
 
     Move best_move = Move::none();
     ScoreType past_eval = -MAX_SCORE;
+    CounterType pv_stability = 0;
     for (CounterType depth = 1; depth <= std::min(td.search_limits.depth, MAX_SEARCH_DEPTH - 1); ++depth) {
         ScoreType eval = aspiration(depth, past_eval, td);
         if (stop_search(td)) // Search did not finished completely
             break;
+
+        if (best_move == td.best_move) { // prev best move is the same as current
+            ++pv_stability;
+        } else {
+            pv_stability = 0;
+        }
 
         best_move = td.best_move;
         past_eval = eval;
@@ -117,7 +124,7 @@ ScoreType iterative_deepening(ThreadData &td) {
             print_search_info(depth, eval, td.nodes[0].pv_list, td);
 
         if (depth > 5)
-            td.time_manager.update(td);
+            td.time_manager.update(td, pv_stability);
         if (td.time_manager.stop_early() || td.nodes_searched >= td.search_limits.optimum_node)
             break;
 

--- a/src/search/time_manager.cpp
+++ b/src/search/time_manager.cpp
@@ -60,13 +60,18 @@ void TimeManager::reset() {
     m_start_time = now();
 }
 
-void TimeManager::update(const ThreadData &td) {
+void TimeManager::update(const ThreadData &td, CounterType pv_stability) {
     if (m_movetime || !m_time_set)
         return;
 
+    const double pv_stability_scale =
+        std::max(tm_pv_stability_base() / 1000.0 - pv_stability * tm_pv_stability_factor() / 1000.0,
+                 tm_pv_stability_min_scale() / 1000.0);
+
     const double node_fraction = td.node_table[td.best_move.from_and_to()] / static_cast<double>(td.nodes_searched);
-    const double node_scaling_factor = (node_tm_base() / 100.0 - node_fraction) * (node_tm_scale() / 100.0);
-    m_scale = std::clamp<double>(node_scaling_factor, tm_min_scale() / 100.0, tm_max_scale() / 100.0);
+    const double node_spent_scale = (tm_node_spent_base() / 1000.0 - node_fraction) * (tm_node_spent_factor() / 1000.0);
+    m_scale =
+        std::clamp<double>(node_spent_scale * pv_stability_scale, tm_min_scale() / 1000.0, tm_max_scale() / 1000.0);
 }
 
 bool TimeManager::stop_early() const { return m_can_stop && time_passed() > m_optimum_time * m_scale; }

--- a/src/search/time_manager.h
+++ b/src/search/time_manager.h
@@ -29,7 +29,7 @@ class TimeManager {
 
     void reset(CounterType inc, CounterType time, CounterType movestogo, CounterType movetime, bool infinite);
     void reset();
-    void update(const ThreadData &td);
+    void update(const ThreadData &td, CounterType pv_stability);
     bool stop_early() const;
     bool time_over() const;
     TimeType time_passed() const;

--- a/src/uci/tune.h
+++ b/src/uci/tune.h
@@ -233,10 +233,14 @@ TUNABLE_PARAM(tm_increment_factor, 75, 20, 120, 5, 0.002)
 TUNABLE_PARAM(tm_opt_time_factor, 75, 20, 100, 5, 0.002)
 TUNABLE_PARAM(tm_max_time_factor, 75, 20, 100, 5, 0.002)
 
-TUNABLE_PARAM(node_tm_base, 150, 100, 200, 5, 0.002)
-TUNABLE_PARAM(node_tm_scale, 160, 100, 300, 5, 0.002)
-TUNABLE_PARAM(tm_min_scale, 50, 10, 100, 5, 0.002)
-TUNABLE_PARAM(tm_max_scale, 250, 150, 350, 5, 0.002)
+TUNABLE_PARAM(tm_pv_stability_base, 1300, 500, 3000, 50, 0.002)
+TUNABLE_PARAM(tm_pv_stability_factor, 50, 10, 200, 5, 0.002)
+TUNABLE_PARAM(tm_pv_stability_min_scale, 700, 200, 2000, 50, 0.002)
+
+TUNABLE_PARAM(tm_node_spent_base, 1500, 1000, 2000, 50, 0.002)
+TUNABLE_PARAM(tm_node_spent_factor, 1600, 1000, 3000, 50, 0.002)
+TUNABLE_PARAM(tm_min_scale, 500, 100, 1000, 50, 0.002)
+TUNABLE_PARAM(tm_max_scale, 2500, 1500, 3500, 50, 0.002)
 
 // Material scale
 TUNABLE_PARAM(pawn_scaling_factor, 98, 20, 160, 5, 0.002)


### PR DESCRIPTION
### STC
```
Elo   | 9.48 +- 5.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4582 W: 1160 L: 1035 D: 2387
Penta | [8, 518, 1135, 601, 29]
```
https://eduardomarinho.dev/test/769/

### LTC
```
Elo   | 4.10 +- 3.06 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 12198 W: 2834 L: 2690 D: 6674
Penta | [12, 1375, 3184, 1513, 15]
```
https://eduardomarinho.dev/test/770/

Bench: 5920747