### PR TITLE
fix(search): properly initialize continuation correction table

### DIFF
--- a/src/search/correction.cpp
+++ b/src/search/correction.cpp
@@ -31,7 +31,8 @@ static inline size_t cont_corr_idx(const PieceMove& pmove) {
 };
 
 void CorrectionHistory::reset() {
-    m_pov_tables = {}; //
+    m_pov_tables = {};
+    m_cont_corr = {};
 }
 
 void CorrectionHistory::update(const ThreadData& td, const int depth, const int diff) {


### PR DESCRIPTION
```
Elo   | 2.22 +- 3.90 (95%)
SPRT  | 2.0+0.02s Threads=1 Hash=32MB
LLR   | 3.06 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 12364 W: 3545 L: 3466 D: 5353
Penta | [243, 1472, 2699, 1499, 269]
```
https://eduardomarinho.dev/test/776/

Bench: 6303948