### PR TITLE
feat(search): time management based on score stability

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -102,12 +102,26 @@ ScoreType iterative_deepening(ThreadData &td) {
     td.stop = false;
 
     Move best_move = Move::none();
-    ScoreType past_eval = -MAX_SCORE;
+    ScoreType past_score = -MAX_SCORE;
+    ScoreType avg_score = SCORE_NONE;
     CounterType pv_stability = 0;
+    CounterType score_stability = 0;
     for (CounterType depth = 1; depth <= std::min(td.search_limits.depth, MAX_SEARCH_DEPTH - 1); ++depth) {
-        ScoreType eval = aspiration(depth, past_eval, td);
+        ScoreType score = aspiration(depth, past_score, td);
         if (stop_search(td)) // Search did not finished completely
             break;
+
+        if (avg_score == SCORE_NONE) {
+            avg_score = score;
+        } else {
+            avg_score = (avg_score + score) / 2;
+        }
+
+        if (std::abs(avg_score - score) < tm_score_stability_delta()) {
+            ++score_stability;
+        } else {
+            score_stability = 0;
+        }
 
         if (best_move == td.best_move) { // prev best move is the same as current
             ++pv_stability;
@@ -116,15 +130,15 @@ ScoreType iterative_deepening(ThreadData &td) {
         }
 
         best_move = td.best_move;
-        past_eval = eval;
+        past_score = score;
         if (!best_move) // No legal moves
             break;
 
         if (td.report)
-            print_search_info(depth, eval, td.nodes[0].pv_list, td);
+            print_search_info(depth, score, td.nodes[0].pv_list, td);
 
         if (depth > 5)
-            td.time_manager.update(td, pv_stability);
+            td.time_manager.update(td, pv_stability, score_stability);
         if (td.time_manager.stop_early() || td.nodes_searched >= td.search_limits.optimum_node)
             break;
 
@@ -138,7 +152,7 @@ ScoreType iterative_deepening(ThreadData &td) {
     td.stop = true;
     td.best_move = best_move; // A partial search would mess this up
     td.tt.update_age();       // Update tt age
-    return past_eval;
+    return past_score;
 }
 
 ScoreType aspiration(const CounterType &depth, const ScoreType prev_score, ThreadData &td) {

--- a/src/search/time_manager.cpp
+++ b/src/search/time_manager.cpp
@@ -60,7 +60,7 @@ void TimeManager::reset() {
     m_start_time = now();
 }
 
-void TimeManager::update(const ThreadData &td, CounterType pv_stability) {
+void TimeManager::update(const ThreadData &td, CounterType pv_stability, CounterType score_stability) {
     if (m_movetime || !m_time_set)
         return;
 
@@ -68,10 +68,15 @@ void TimeManager::update(const ThreadData &td, CounterType pv_stability) {
         std::max(tm_pv_stability_base() / 1000.0 - pv_stability * tm_pv_stability_factor() / 1000.0,
                  tm_pv_stability_min_scale() / 1000.0);
 
+    const double score_stability_scale =
+        std::max(tm_score_stability_base() / 1000.0 - score_stability * tm_score_stability_factor() / 1000.0,
+                 tm_score_stability_min_scale() / 1000.0);
+
     const double node_fraction = td.node_table[td.best_move.from_and_to()] / static_cast<double>(td.nodes_searched);
     const double node_spent_scale = (tm_node_spent_base() / 1000.0 - node_fraction) * (tm_node_spent_factor() / 1000.0);
-    m_scale =
-        std::clamp<double>(node_spent_scale * pv_stability_scale, tm_min_scale() / 1000.0, tm_max_scale() / 1000.0);
+
+    m_scale = std::clamp<double>(node_spent_scale * pv_stability_scale * score_stability_scale, tm_min_scale() / 1000.0,
+                                 tm_max_scale() / 1000.0);
 }
 
 bool TimeManager::stop_early() const { return m_can_stop && time_passed() > m_optimum_time * m_scale; }

--- a/src/search/time_manager.h
+++ b/src/search/time_manager.h
@@ -29,7 +29,7 @@ class TimeManager {
 
     void reset(CounterType inc, CounterType time, CounterType movestogo, CounterType movetime, bool infinite);
     void reset();
-    void update(const ThreadData &td, CounterType pv_stability);
+    void update(const ThreadData &td, CounterType pv_stability, CounterType score_stability);
     bool stop_early() const;
     bool time_over() const;
     TimeType time_passed() const;

--- a/src/uci/tune.h
+++ b/src/uci/tune.h
@@ -237,6 +237,11 @@ TUNABLE_PARAM(tm_pv_stability_base, 1280, 500, 3000, 50, 0.002)
 TUNABLE_PARAM(tm_pv_stability_factor, 50, 10, 200, 5, 0.002)
 TUNABLE_PARAM(tm_pv_stability_min_scale, 728, 200, 2000, 50, 0.002)
 
+TUNABLE_PARAM(tm_score_stability_delta, 12, 2, 40, 1, 0.002)
+TUNABLE_PARAM(tm_score_stability_base, 1280, 500, 3000, 50, 0.002)
+TUNABLE_PARAM(tm_score_stability_factor, 50, 10, 200, 5, 0.002)
+TUNABLE_PARAM(tm_score_stability_min_scale, 728, 200, 2000, 50, 0.002)
+
 TUNABLE_PARAM(tm_node_spent_base, 1516, 1000, 2000, 50, 0.002)
 TUNABLE_PARAM(tm_node_spent_factor, 1627, 1000, 3000, 50, 0.002)
 TUNABLE_PARAM(tm_min_scale, 527, 100, 1000, 50, 0.002)


### PR DESCRIPTION
### STC
```
Elo   | 3.22 +- 2.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.27 (-2.25, 2.89) [0.00, 5.00]
Games | N: 21452 W: 5159 L: 4960 D: 11333
Penta | [76, 2513, 5345, 2720, 72]
```
https://eduardomarinho.dev/test/778/

### LTC
```
Elo   | 3.37 +- 2.60 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 16186 W: 3741 L: 3584 D: 8861
Penta | [8, 1799, 4327, 1946, 13]
```
https://eduardomarinho.dev/test/777/

Bench: 5920747