### PR TITLE
feat(search): no move picker bonus for counter move

### DIFF
--- a/src/search/movepicker.cpp
+++ b/src/search/movepicker.cpp
@@ -45,12 +45,6 @@ void MovePicker::init(Move ttmove, ThreadData &td, MovePickerType mp_type, Score
     m_killer1 = m_td->search_history.consult_killer1(m_td->height);
     m_killer2 = m_td->search_history.consult_killer2(m_td->height);
 
-    m_counter = Move::none();
-    if (m_td->height > 0)
-        m_counter = m_td->search_history.consult_counter(m_td->nodes[m_td->height - 1].curr_pmove.move);
-    if (m_counter == m_killer1 || m_counter == m_killer2)
-        m_counter = Move::none();
-
     m_idx = m_end = m_bad_noisy_end = 0;
 }
 
@@ -147,8 +141,6 @@ void MovePicker::score_quiet_moves() {
             score += mp_killer1_bonus();
         else if (move == m_killer2)
             score += mp_killer2_bonus();
-        else if (move == m_counter)
-            score += mp_counter_bonus();
     }
 }
 

--- a/src/search/movepicker.h
+++ b/src/search/movepicker.h
@@ -61,7 +61,7 @@ class MovePicker {
     MovePickerStage m_stage;
     Movegen::ScoredMoveList m_move_list;
     size_t m_idx, m_end, m_bad_noisy_end;
-    Move m_ttmove, m_killer1, m_killer2, m_counter;
+    Move m_ttmove, m_killer1, m_killer2;
     ThreadData *m_td;
     ScoreType m_threshold;
 };

--- a/src/uci/tune.h
+++ b/src/uci/tune.h
@@ -271,4 +271,3 @@ const int SEE_VALUES[PIECE_NB] = {pawn_see_value(), knight_see_value(), bishop_s
 TUNABLE_PARAM(mp_see_threshold_base, 78, 0, 150, 5, 0.002)
 TUNABLE_PARAM(mp_killer1_bonus, 8591, 0, 16000, 400, 0.002)
 TUNABLE_PARAM(mp_killer2_bonus, 6387, 0, 16000, 400, 0.002)
-TUNABLE_PARAM(mp_counter_bonus, 3025, 0, 16000, 400, 0.002)


### PR DESCRIPTION
### STC
```
Elo   | -0.85 +- 1.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.70 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 33222 W: 7733 L: 7814 D: 17675
Penta | [129, 3996, 8443, 3913, 130]
```
https://eduardomarinho.dev/test/788/
### LTC
```
Elo   | 0.16 +- 1.92 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.33 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 30294 W: 6753 L: 6739 D: 16802
Penta | [33, 3533, 7988, 3573, 20]
```
https://eduardomarinho.dev/test/789/

Bench: 5749621

yolo