### PR TITLE
feat(eval): change default network to `minke36`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ elseif(UNIX)
 endif()
 
 # Define EVALFILE and make init.cpp recompiled when EVALFILE has changed
-set(EVALFILE "${CMAKE_SOURCE_DIR}/minke35.nnue")
+set(EVALFILE "${CMAKE_SOURCE_DIR}/minke36.nnue")
 target_compile_definitions(minke PRIVATE EVALFILE=\"${EVALFILE}\")
 set_property(
   SOURCE ${CMAKE_SOURCE_DIR}/src/init.cpp

--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@
 #   make EVALFILE=net.nnue bmi2                     # use a custom network file
 
 VERSION := 6.0.0
-DEFAULT_EVALFILE := minke35
+DEFAULT_EVALFILE := minke36
 
 PGO ?= off
 


### PR DESCRIPTION
#### Fixed nodes (25ksn)
```
Elo   : -0.44 +- 3.16 (95%)             
SPRT  : N=25000 Threads=1 Hash=8MB      
Games : N: 22714 W: 7049 L: 7078 D: 8587
Penta : [747, 2635, 4583, 2684, 708]    
LLR   : -2.95 (-2.94, 2.94) [0.00, 5.00]
```
(not done with OpenBench)               
                                        
#### STC 
```
Elo   : 5.00 +- 3.53 (95%)              
SPRT  : 8.0+0.08s Threads=1 Hash=32MB   
LLR   : 3.00 (-2.25, 2.89) [0.00, 5.00] 
Games : N: 10414 W: 2568 L: 2418 D: 5428
Penta : [41, 1212, 2559, 1346, 49]    
```  
https://eduardomarinho.dev/test/801/    

#### LTC
```
 Elo   : 3.74 +- 2.82 (95%)                  
 SPRT  : 40.0+0.40s Threads=1 Hash=128MB     
 LLR   : 2.99 (-2.25, 2.89) [0.00, 5.00]     
 Games : N: 14206 W: 3348 L: 3195 D: 7663    
 Penta : [24, 1567, 3760, 1736, 16]          
```
 https://eduardomarinho.dev/test/802/        


Bench: 5165581