### PR TITLE
feat(search): update continuation history score with base

### DIFF
--- a/src/search/history.cpp
+++ b/src/search/history.cpp
@@ -109,17 +109,19 @@ void History::update_history_heuristic_score(const Position &position, const Mov
 }
 
 void History::update_continuation_history_table(const ThreadData &td, const PieceMove &pmove, int bonus) {
-    update_continuation_history_score(td, pmove, bonus, 1); // Counter Moves History (1-ply)
-    update_continuation_history_score(td, pmove, bonus, 2); // Follow Up History (2-ply)
-    update_continuation_history_score(td, pmove, bonus, 4); // 4-ply
+    const int base = get_continuation_history_score(td, pmove);
+    update_continuation_history_score(td, pmove, bonus, base, 1); // Counter Moves History (1-ply)
+    update_continuation_history_score(td, pmove, bonus, base, 2); // Follow Up History (2-ply)
+    update_continuation_history_score(td, pmove, bonus, base, 4); // 4-ply
 }
 
-void History::update_continuation_history_score(const ThreadData &td, const PieceMove &pmove, int bonus, int offset) {
+void History::update_continuation_history_score(const ThreadData &td, const PieceMove &pmove, int bonus, int base,
+                                                int offset) {
     int past_node_idx = td.height - offset;
     if (past_node_idx >= 0 && td.nodes[past_node_idx].curr_pmove) {
         const size_t past_conthist_idx = cont_hist_idx(td.nodes[past_node_idx].curr_pmove);
         const size_t curr_conthist_idx = cont_hist_idx(pmove);
-        m_continuation_history[past_conthist_idx][curr_conthist_idx].update_score(bonus);
+        m_continuation_history[past_conthist_idx][curr_conthist_idx].update_with_base(bonus, base);
     }
 }
 

--- a/src/search/history.h
+++ b/src/search/history.h
@@ -68,13 +68,15 @@ class History {
         HistoryType value{};
 
         inline void update_score(int bonus) { value += bonus - value * std::abs(bonus) / HISTORY_DIVISOR; }
+        inline void update_with_base(int bonus, int base) { value += bonus - base * std::abs(bonus) / HISTORY_DIVISOR; }
     };
 
     void update_capture_history_score(const Position &position, const Move &move, int bonus);
     void update_history_heuristic_score(const Position &position, const Move &move, int bonus);
     void update_continuation_history_table(const ThreadData &td, const PieceMove &pmove, int bonus);
 
-    void update_continuation_history_score(const ThreadData &td, const PieceMove &pmove, int bonus, int offset);
+    void update_continuation_history_score(const ThreadData &td, const PieceMove &pmove, int bonus, int base,
+                                           int offset);
     HistoryType get_history_heuristic_score(const Position &position, const Move &move) const;
     int get_continuation_history_score(const ThreadData &td, const PieceMove &pmove) const;
     HistoryType get_continuation_history_entry(const ThreadData &td, const PieceMove &pmove, int offset) const;


### PR DESCRIPTION
STC
```
Elo   | 3.39 +- 2.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 17504 W: 4262 L: 4091 D: 9151
Penta | [51, 2014, 4475, 2137, 75]
```
https://eduardomarinho.dev/test/821/

LTC
```
Elo   | 4.71 +- 3.36 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9818 W: 2272 L: 2139 D: 5407
Penta | [5, 1085, 2599, 1212, 8]
```
https://eduardomarinho.dev/test/822/

Bench: 6088620