### PR TITLE
feat(search): remove counter move heuristic

### DIFF
--- a/src/search/history.cpp
+++ b/src/search/history.cpp
@@ -47,9 +47,6 @@ void History::reset() {
         moves[0] = Move::none();
         moves[1] = Move::none();
     }
-    for (Move &move : m_counter_moves) {
-        move = Move::none();
-    }
 };
 
 int History::get_history(const ThreadData &td, const Move &move) const {
@@ -69,8 +66,6 @@ void History::update_history(const ThreadData &td, const Move &best_move, int de
         calculate_score(depth, capt_hist_penalty_mult(), capt_hist_penalty_offset(), capt_hist_penalty_max());
     if (best_move.is_quiet()) {
         save_killer(best_move, td.height);
-        if (td.height > 0)
-            save_counter(td.nodes[td.height - 1].curr_pmove.move, best_move);
 
         // Increase the score of the move that caused the beta cutoff
         update_history_heuristic_score(td.position, best_move, quiet_bonus);

--- a/src/search/history.h
+++ b/src/search/history.h
@@ -53,15 +53,9 @@ class History {
     }
     inline Move consult_killer1(const int &height) const { return m_killer_moves[height][0]; }
     inline Move consult_killer2(const int &height) const { return m_killer_moves[height][1]; }
-    inline Move consult_counter(const Move &past_move) const {
-        if (!past_move)
-            return Move::none();
-        return m_counter_moves[past_move.from_and_to()];
-    }
     inline bool is_killer(const Move &move, const int &height) const {
         return move == consult_killer1(height) || move == consult_killer2(height);
     }
-    inline bool is_counter(const Move &move, const Move &past_move) const { return move == consult_counter(past_move); }
 
   private:
     struct HistoryEntry {
@@ -86,14 +80,8 @@ class History {
         m_killer_moves[height][0] = move;
     }
 
-    inline void save_counter(const Move &past_move, const Move &move) {
-        if (past_move)
-            m_counter_moves[past_move.from_and_to()] = move;
-    }
-
     HistoryEntry m_capture_history[2][6][64][5][2];
     HistoryEntry m_search_history_table[2][64 * 64][2][2];
     HistoryEntry m_continuation_history[12 * 64][12 * 64];
-    Move m_counter_moves[64 * 64];
     Move m_killer_moves[MAX_SEARCH_DEPTH][2];
 };

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -482,11 +482,8 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                 scaled_reduction += !improving * lmr_non_improving_delta(); // Reduce more if not improving
                 scaled_reduction += cutnode * lmr_cutnode_delta();          // Reduce cutnodes more
 
-                // Reduce less if move is killer or counter
+                // Reduce less if move is killer
                 scaled_reduction -= td.search_history.is_killer(move, td.height - 1) * lmr_killer_delta();
-                if (td.height >= 2)
-                    scaled_reduction -= td.search_history.is_counter(move, td.nodes[td.height - 2].curr_pmove.move) *
-                                        lmr_counter_delta();
 
                 // Reduce less if this move is or was a principal variation
                 scaled_reduction -= ttpv * lmr_ttpv_delta();


### PR DESCRIPTION
```
Elo   | -0.76 +- 2.35 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.29 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 20034 W: 4501 L: 4545 D: 10988
Penta | [22, 2340, 5330, 2310, 15]
```
https://eduardomarinho.dev/test/824/

Bench: 6066442