### PR TITLE
fix(core): reset fifty move count after a promotion

### DIFF
--- a/src/core/position.cpp
+++ b/src/core/position.cpp
@@ -431,6 +431,8 @@ DirtyPiece Position::make_promotion(const Move &move) {
     const Square from = move.from();
     const Square to = move.to();
 
+    m_curr_state.fifty_move_ply = 0;
+
     DirtyPiece dp;
     dp.move_type = REGULAR;
     dp.sub0 = {piece_at(from), from};


### PR DESCRIPTION
quick sanity check: 
```
Elo   | 0.52 +- 2.92 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 1.72 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 11414 W: 2759 L: 2742 D: 5913
Penta | [37, 1033, 3560, 1030, 47]
```
https://eduardomarinho.dev/test/839/

Bench: 5880334