### PR TITLE
feat(search): don't perform IIR when in singular search

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -237,7 +237,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
     }
 
     // Internal Iterative Reductions
-    if ((!tthit || ttdepth + 4 < depth) && depth >= 3) {
+    if (!singular_search && (!tthit || ttdepth + 4 < depth) && depth >= 3) {
         depth -= 1;
     }
 


### PR DESCRIPTION
```
Elo   | 1.30 +- 1.79 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.23 (-2.25, 2.89) [0.00, 5.00]
Games | N: 34452 W: 7763 L: 7634 D: 19055
Penta | [31, 3923, 9191, 4048, 33]
```
https://eduardomarinho.dev/test/794/

Bench: 5658058

yolo; 