### PR TITLE
refactor(search): replace mutable td.height with explicit ply parameter

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -167,6 +167,17 @@ inline TimeType now() {
         .count();
 }
 
+inline ScoreType normalize_score(ScoreType score) {
+    // TODO scores should be normalize such that +100/-100 means 50% chance of wining or losing
+    return score / 2;
+}
+
+inline static bool is_mate(const ScoreType score) { return score > MATE_FOUND; }
+
+inline static bool is_mated(const ScoreType score) { return score < -MATE_FOUND; }
+
+inline static bool is_decisive(const ScoreType score) { return is_mate(score) || is_mated(score); }
+
 struct PieceSquare {
     Piece piece;
     Square sq;

--- a/src/search/correction.cpp
+++ b/src/search/correction.cpp
@@ -35,7 +35,7 @@ void CorrectionHistory::reset() {
     m_cont_corr = {};
 }
 
-void CorrectionHistory::update(const ThreadData& td, const int depth, const int diff) {
+void CorrectionHistory::update(const ThreadData& td, int depth, int ply, int diff) {
     const HistoryType bonus = std::clamp(diff * depth / 8, -CORRHIST_MAX / 4, CORRHIST_MAX / 4);
 
     PovTables& tables = m_pov_tables[td.position.stm()];
@@ -45,9 +45,9 @@ void CorrectionHistory::update(const ThreadData& td, const int depth, const int 
     tables.black_nonpawn[td.position.black_nonpawn_hash() % CORRHIST_SIZE].update(bonus);
 
     auto update_cont = [&](int offset) {
-        if (td.ply >= offset + 1) {
-            const PieceMove curr_pmove = td.nodes[td.ply - 1].curr_pmove;
-            const PieceMove past_pmove = td.nodes[td.ply - offset - 1].curr_pmove;
+        if (ply >= offset + 1) {
+            const PieceMove curr_pmove = td.nodes[ply - 1].curr_pmove;
+            const PieceMove past_pmove = td.nodes[ply - offset - 1].curr_pmove;
 
             if (curr_pmove && past_pmove) {
                 m_cont_corr[cont_corr_idx(curr_pmove)][cont_corr_idx(past_pmove)].update(bonus);
@@ -58,7 +58,7 @@ void CorrectionHistory::update(const ThreadData& td, const int depth, const int 
     update_cont(2);
 }
 
-HistoryType CorrectionHistory::correction(const ThreadData& td) const {
+HistoryType CorrectionHistory::correction(const ThreadData& td, int ply) const {
     const PovTables& tables = m_pov_tables[td.position.stm()];
 
     int adjustment = pawn_corr_factor() * tables.pawn[td.position.pawn_hash() % CORRHIST_SIZE];
@@ -66,9 +66,9 @@ HistoryType CorrectionHistory::correction(const ThreadData& td) const {
     adjustment += nonpawn_corr_factor() * tables.black_nonpawn[td.position.black_nonpawn_hash() % CORRHIST_SIZE];
 
     auto adjust_cont = [&](int offset) {
-        if (td.ply >= offset + 1) {
-            const PieceMove pmove1 = td.nodes[td.ply - 1].curr_pmove;
-            const PieceMove pmove2 = td.nodes[td.ply - offset - 1].curr_pmove;
+        if (ply >= offset + 1) {
+            const PieceMove pmove1 = td.nodes[ply - 1].curr_pmove;
+            const PieceMove pmove2 = td.nodes[ply - offset - 1].curr_pmove;
             if (pmove1 && pmove2) {
                 adjustment += cont_corr_factor() * m_cont_corr[cont_corr_idx(pmove1)][cont_corr_idx(pmove2)];
             }

--- a/src/search/correction.cpp
+++ b/src/search/correction.cpp
@@ -45,9 +45,9 @@ void CorrectionHistory::update(const ThreadData& td, const int depth, const int 
     tables.black_nonpawn[td.position.black_nonpawn_hash() % CORRHIST_SIZE].update(bonus);
 
     auto update_cont = [&](int offset) {
-        if (td.height >= offset + 1) {
-            const PieceMove curr_pmove = td.nodes[td.height - 1].curr_pmove;
-            const PieceMove past_pmove = td.nodes[td.height - offset - 1].curr_pmove;
+        if (td.ply >= offset + 1) {
+            const PieceMove curr_pmove = td.nodes[td.ply - 1].curr_pmove;
+            const PieceMove past_pmove = td.nodes[td.ply - offset - 1].curr_pmove;
 
             if (curr_pmove && past_pmove) {
                 m_cont_corr[cont_corr_idx(curr_pmove)][cont_corr_idx(past_pmove)].update(bonus);
@@ -66,9 +66,9 @@ HistoryType CorrectionHistory::correction(const ThreadData& td) const {
     adjustment += nonpawn_corr_factor() * tables.black_nonpawn[td.position.black_nonpawn_hash() % CORRHIST_SIZE];
 
     auto adjust_cont = [&](int offset) {
-        if (td.height >= offset + 1) {
-            const PieceMove pmove1 = td.nodes[td.height - 1].curr_pmove;
-            const PieceMove pmove2 = td.nodes[td.height - offset - 1].curr_pmove;
+        if (td.ply >= offset + 1) {
+            const PieceMove pmove1 = td.nodes[td.ply - 1].curr_pmove;
+            const PieceMove pmove2 = td.nodes[td.ply - offset - 1].curr_pmove;
             if (pmove1 && pmove2) {
                 adjustment += cont_corr_factor() * m_cont_corr[cont_corr_idx(pmove1)][cont_corr_idx(pmove2)];
             }

--- a/src/search/correction.cpp
+++ b/src/search/correction.cpp
@@ -46,8 +46,8 @@ void CorrectionHistory::update(const ThreadData& td, int depth, int ply, int dif
 
     auto update_cont = [&](int offset) {
         if (ply >= offset + 1) {
-            const PieceMove curr_pmove = td.nodes[ply - 1].curr_pmove;
-            const PieceMove past_pmove = td.nodes[ply - offset - 1].curr_pmove;
+            const PieceMove curr_pmove = td.search_stack[ply - 1].curr_pmove;
+            const PieceMove past_pmove = td.search_stack[ply - offset - 1].curr_pmove;
 
             if (curr_pmove && past_pmove) {
                 m_cont_corr[cont_corr_idx(curr_pmove)][cont_corr_idx(past_pmove)].update(bonus);
@@ -67,8 +67,8 @@ HistoryType CorrectionHistory::correction(const ThreadData& td, int ply) const {
 
     auto adjust_cont = [&](int offset) {
         if (ply >= offset + 1) {
-            const PieceMove pmove1 = td.nodes[ply - 1].curr_pmove;
-            const PieceMove pmove2 = td.nodes[ply - offset - 1].curr_pmove;
+            const PieceMove pmove1 = td.search_stack[ply - 1].curr_pmove;
+            const PieceMove pmove2 = td.search_stack[ply - offset - 1].curr_pmove;
             if (pmove1 && pmove2) {
                 adjustment += cont_corr_factor() * m_cont_corr[cont_corr_idx(pmove1)][cont_corr_idx(pmove2)];
             }

--- a/src/search/correction.h
+++ b/src/search/correction.h
@@ -35,9 +35,9 @@ class CorrectionHistory {
 
     void reset();
 
-    void update(const ThreadData& td, const int depth, const int diff);
+    void update(const ThreadData& td, int depth, int ply, int diff);
 
-    HistoryType correction(const ThreadData& td) const;
+    HistoryType correction(const ThreadData& td, int ply) const;
 
   private:
     struct CorrectionEntry {

--- a/src/search/history.cpp
+++ b/src/search/history.cpp
@@ -65,7 +65,7 @@ void History::update_history(const ThreadData &td, const Move &best_move, int de
     HistoryType capture_penalty =
         calculate_score(depth, capt_hist_penalty_mult(), capt_hist_penalty_offset(), capt_hist_penalty_max());
     if (best_move.is_quiet()) {
-        save_killer(best_move, td.height);
+        save_killer(best_move, td.ply);
 
         // Increase the score of the move that caused the beta cutoff
         update_history_heuristic_score(td.position, best_move, quiet_bonus);
@@ -112,7 +112,7 @@ void History::update_continuation_history_table(const ThreadData &td, const Piec
 
 void History::update_continuation_history_score(const ThreadData &td, const PieceMove &pmove, int bonus, int base,
                                                 int offset) {
-    int past_node_idx = td.height - offset;
+    int past_node_idx = td.ply - offset;
     if (past_node_idx >= 0 && td.nodes[past_node_idx].curr_pmove) {
         const size_t past_conthist_idx = cont_hist_idx(td.nodes[past_node_idx].curr_pmove);
         const size_t curr_conthist_idx = cont_hist_idx(pmove);
@@ -136,7 +136,7 @@ int History::get_continuation_history_score(const ThreadData &td, const PieceMov
 }
 
 HistoryType History::get_continuation_history_entry(const ThreadData &td, const PieceMove &pmove, int offset) const {
-    int past_node_idx = td.height - offset;
+    int past_node_idx = td.ply - offset;
     if (past_node_idx < 0 || !td.nodes[past_node_idx].curr_pmove)
         return 0;
 

--- a/src/search/history.cpp
+++ b/src/search/history.cpp
@@ -49,13 +49,13 @@ void History::reset() {
     }
 };
 
-int History::get_history(const ThreadData &td, const Move &move) const {
+int History::get_history(const ThreadData &td, const Move &move, CounterType ply) const {
     PieceMove pmove = {move, td.position.piece_at(move.from())};
-    return get_history_heuristic_score(td.position, move) + get_continuation_history_score(td, pmove);
+    return get_history_heuristic_score(td.position, move) + get_continuation_history_score(td, pmove, ply);
 }
 
-void History::update_history(const ThreadData &td, const Move &best_move, int depth, const PieceMoveList &quiets_tried,
-                             const PieceMoveList &tacticals_tried) {
+void History::update_history(const ThreadData &td, const Move &best_move, int depth, CounterType ply,
+                             const PieceMoveList &quiets_tried, const PieceMoveList &tacticals_tried) {
     HistoryType quiet_bonus = calculate_score(depth, hist_bonus_mult(), hist_bonus_offset(), hist_bonus_max());
     HistoryType quiet_penalty = calculate_score(depth, hist_penalty_mult(), hist_penalty_offset(), hist_penalty_max());
     HistoryType cont_bonus = calculate_score(depth, cont_bonus_mult(), cont_bonus_offset(), cont_bonus_max());
@@ -65,16 +65,16 @@ void History::update_history(const ThreadData &td, const Move &best_move, int de
     HistoryType capture_penalty =
         calculate_score(depth, capt_hist_penalty_mult(), capt_hist_penalty_offset(), capt_hist_penalty_max());
     if (best_move.is_quiet()) {
-        save_killer(best_move, td.ply);
+        save_killer(best_move, ply);
 
         // Increase the score of the move that caused the beta cutoff
         update_history_heuristic_score(td.position, best_move, quiet_bonus);
-        update_continuation_history_table(td, quiets_tried.back(), cont_bonus);
+        update_continuation_history_table(td, quiets_tried.back(), cont_bonus, ply);
 
         // Decrease all the quiet moves scores that did not caused a beta cutoff
         for (size_t idx = 0; idx < quiets_tried.size() - 1; ++idx) {
             update_history_heuristic_score(td.position, quiets_tried[idx].move, quiet_penalty);
-            update_continuation_history_table(td, quiets_tried[idx], cont_penalty);
+            update_continuation_history_table(td, quiets_tried[idx], cont_penalty, ply);
         }
 
     } else {
@@ -103,16 +103,17 @@ void History::update_history_heuristic_score(const Position &position, const Mov
     m_search_history_table[position.stm()][move.from_and_to()][from_threatened][to_threatened].update_score(bonus);
 }
 
-void History::update_continuation_history_table(const ThreadData &td, const PieceMove &pmove, int bonus) {
-    const int base = get_continuation_history_score(td, pmove);
-    update_continuation_history_score(td, pmove, bonus, base, 1); // Counter Moves History (1-ply)
-    update_continuation_history_score(td, pmove, bonus, base, 2); // Follow Up History (2-ply)
-    update_continuation_history_score(td, pmove, bonus, base, 4); // 4-ply
+void History::update_continuation_history_table(const ThreadData &td, const PieceMove &pmove, int bonus,
+                                                CounterType ply) {
+    const int base = get_continuation_history_score(td, pmove, ply);
+    update_continuation_history_score(td, pmove, bonus, base, ply, 1); // Counter Moves History (1-ply)
+    update_continuation_history_score(td, pmove, bonus, base, ply, 2); // Follow Up History (2-ply)
+    update_continuation_history_score(td, pmove, bonus, base, ply, 4); // 4-ply
 }
 
 void History::update_continuation_history_score(const ThreadData &td, const PieceMove &pmove, int bonus, int base,
-                                                int offset) {
-    int past_node_idx = td.ply - offset;
+                                                CounterType ply, int offset) {
+    int past_node_idx = ply - offset;
     if (past_node_idx >= 0 && td.nodes[past_node_idx].curr_pmove) {
         const size_t past_conthist_idx = cont_hist_idx(td.nodes[past_node_idx].curr_pmove);
         const size_t curr_conthist_idx = cont_hist_idx(pmove);
@@ -126,17 +127,18 @@ HistoryType History::get_history_heuristic_score(const Position &position, const
     return m_search_history_table[position.stm()][move.from_and_to()][from_threatened][to_threatened].value;
 }
 
-int History::get_continuation_history_score(const ThreadData &td, const PieceMove &pmove) const {
+int History::get_continuation_history_score(const ThreadData &td, const PieceMove &pmove, CounterType ply) const {
     int conthist = 0;
-    conthist += get_continuation_history_entry(td, pmove, 1) * conthist_1ply_weight();
-    conthist += get_continuation_history_entry(td, pmove, 2) * conthist_2ply_weight();
-    conthist += get_continuation_history_entry(td, pmove, 4) * conthist_4ply_weight();
+    conthist += get_continuation_history_entry(td, pmove, ply, 1) * conthist_1ply_weight();
+    conthist += get_continuation_history_entry(td, pmove, ply, 2) * conthist_2ply_weight();
+    conthist += get_continuation_history_entry(td, pmove, ply, 4) * conthist_4ply_weight();
 
     return conthist / 1024;
 }
 
-HistoryType History::get_continuation_history_entry(const ThreadData &td, const PieceMove &pmove, int offset) const {
-    int past_node_idx = td.ply - offset;
+HistoryType History::get_continuation_history_entry(const ThreadData &td, const PieceMove &pmove, CounterType ply,
+                                                    int offset) const {
+    int past_node_idx = ply - offset;
     if (past_node_idx < 0 || !td.nodes[past_node_idx].curr_pmove)
         return 0;
 

--- a/src/search/history.cpp
+++ b/src/search/history.cpp
@@ -114,8 +114,8 @@ void History::update_continuation_history_table(const ThreadData &td, const Piec
 void History::update_continuation_history_score(const ThreadData &td, const PieceMove &pmove, int bonus, int base,
                                                 CounterType ply, int offset) {
     int past_node_idx = ply - offset;
-    if (past_node_idx >= 0 && td.nodes[past_node_idx].curr_pmove) {
-        const size_t past_conthist_idx = cont_hist_idx(td.nodes[past_node_idx].curr_pmove);
+    if (past_node_idx >= 0 && td.search_stack[past_node_idx].curr_pmove) {
+        const size_t past_conthist_idx = cont_hist_idx(td.search_stack[past_node_idx].curr_pmove);
         const size_t curr_conthist_idx = cont_hist_idx(pmove);
         m_continuation_history[past_conthist_idx][curr_conthist_idx].update_with_base(bonus, base);
     }
@@ -139,10 +139,10 @@ int History::get_continuation_history_score(const ThreadData &td, const PieceMov
 HistoryType History::get_continuation_history_entry(const ThreadData &td, const PieceMove &pmove, CounterType ply,
                                                     int offset) const {
     int past_node_idx = ply - offset;
-    if (past_node_idx < 0 || !td.nodes[past_node_idx].curr_pmove)
+    if (past_node_idx < 0 || !td.search_stack[past_node_idx].curr_pmove)
         return 0;
 
-    const size_t past_conthist_idx = cont_hist_idx(td.nodes[past_node_idx].curr_pmove);
+    const size_t past_conthist_idx = cont_hist_idx(td.search_stack[past_node_idx].curr_pmove);
     const size_t curr_conthist_idx = cont_hist_idx(pmove);
     return m_continuation_history[past_conthist_idx][curr_conthist_idx].value;
 }

--- a/src/search/history.h
+++ b/src/search/history.h
@@ -33,10 +33,10 @@ class History {
 
     void reset();
 
-    void update_history(const ThreadData &td, const Move &best_move, int depth, const PieceMoveList &quiets_tried,
-                        const PieceMoveList &tacticals_tried);
+    void update_history(const ThreadData &td, const Move &best_move, int depth, CounterType ply,
+                        const PieceMoveList &quiets_tried, const PieceMoveList &tacticals_tried);
 
-    int get_history(const ThreadData &td, const Move &move) const;
+    int get_history(const ThreadData &td, const Move &move, CounterType ply) const;
 
     inline HistoryType get_capture_history(const Position &position, const Move &move) {
         Square to = move.to();
@@ -67,13 +67,14 @@ class History {
 
     void update_capture_history_score(const Position &position, const Move &move, int bonus);
     void update_history_heuristic_score(const Position &position, const Move &move, int bonus);
-    void update_continuation_history_table(const ThreadData &td, const PieceMove &pmove, int bonus);
+    void update_continuation_history_table(const ThreadData &td, const PieceMove &pmove, int bonus, CounterType ply);
 
     void update_continuation_history_score(const ThreadData &td, const PieceMove &pmove, int bonus, int base,
-                                           int offset);
+                                           CounterType ply, int offset);
     HistoryType get_history_heuristic_score(const Position &position, const Move &move) const;
-    int get_continuation_history_score(const ThreadData &td, const PieceMove &pmove) const;
-    HistoryType get_continuation_history_entry(const ThreadData &td, const PieceMove &pmove, int offset) const;
+    int get_continuation_history_score(const ThreadData &td, const PieceMove &pmove, CounterType ply) const;
+    HistoryType get_continuation_history_entry(const ThreadData &td, const PieceMove &pmove, CounterType ply,
+                                               int offset) const;
 
     inline void save_killer(const Move &move, const int height) {
         m_killer_moves[height][1] = m_killer_moves[height][0];

--- a/src/search/movepicker.cpp
+++ b/src/search/movepicker.cpp
@@ -42,8 +42,8 @@ void MovePicker::init(Move ttmove, ThreadData &td, MovePickerType mp_type, Score
     else
         m_stage = GEN_NOISY;
 
-    m_killer1 = m_td->search_history.consult_killer1(m_td->height);
-    m_killer2 = m_td->search_history.consult_killer2(m_td->height);
+    m_killer1 = m_td->search_history.consult_killer1(m_td->ply);
+    m_killer2 = m_td->search_history.consult_killer2(m_td->ply);
 
     m_idx = m_end = m_bad_noisy_end = 0;
 }

--- a/src/search/movepicker.cpp
+++ b/src/search/movepicker.cpp
@@ -26,12 +26,13 @@
 #include "search/search.h"
 #include "uci/tune.h"
 
-MovePicker::MovePicker(Move ttmove, ThreadData &td, MovePickerType mp_type, ScoreType threshold) {
-    init(ttmove, td, mp_type, threshold);
+MovePicker::MovePicker(Move ttmove, ThreadData &td, int ply, MovePickerType mp_type, ScoreType threshold) {
+    init(ttmove, td, ply, mp_type, threshold);
 }
 
-void MovePicker::init(Move ttmove, ThreadData &td, MovePickerType mp_type, ScoreType threshold) {
+void MovePicker::init(Move ttmove, ThreadData &td, int ply, MovePickerType mp_type, ScoreType threshold) {
     m_td = &td;
+    m_ply = ply;
     m_ttmove = ttmove;
     m_mp_type = mp_type;
     m_threshold = threshold;
@@ -42,8 +43,8 @@ void MovePicker::init(Move ttmove, ThreadData &td, MovePickerType mp_type, Score
     else
         m_stage = GEN_NOISY;
 
-    m_killer1 = m_td->search_history.consult_killer1(m_td->ply);
-    m_killer2 = m_td->search_history.consult_killer2(m_td->ply);
+    m_killer1 = m_td->search_history.consult_killer1(m_ply);
+    m_killer2 = m_td->search_history.consult_killer2(m_ply);
 
     m_idx = m_end = m_bad_noisy_end = 0;
 }
@@ -137,7 +138,7 @@ size_t MovePicker::sort_next_move() {
 void MovePicker::score_quiet_moves() {
     for (size_t i = m_idx; i < m_end; ++i) {
         auto &[move, score] = m_move_list[i];
-        score = m_td->search_history.get_history(*m_td, move);
+        score = m_td->search_history.get_history(*m_td, move, m_ply);
         if (move == m_killer1)
             score += mp_killer1_bonus();
         else if (move == m_killer2)

--- a/src/search/movepicker.h
+++ b/src/search/movepicker.h
@@ -43,10 +43,10 @@ enum MovePickerType {
 class MovePicker {
   public:
     MovePicker() = default;
-    MovePicker(Move ttmove, ThreadData &td, MovePickerType mp_type, ScoreType threshold = 0);
+    MovePicker(Move ttmove, ThreadData &td, int ply, MovePickerType mp_type, ScoreType threshold = 0);
     ~MovePicker() = default;
 
-    void init(Move ttmove, ThreadData &td, MovePickerType mp_type, ScoreType threshold = 0);
+    void init(Move ttmove, ThreadData &td, int ply, MovePickerType mp_type, ScoreType threshold = 0);
     Move next_move(const bool skip_quiets);
     ScoredMove next_move_scored(const bool skip_quiets);
 
@@ -64,4 +64,5 @@ class MovePicker {
     Move m_ttmove, m_killer1, m_killer2;
     ThreadData *m_td;
     ScoreType m_threshold;
+    int m_ply;
 };

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -75,7 +75,7 @@ void ThreadData::reset_search_parameters() {
     search_limiter.init();
     // TODO i dont think this is necessary
     for (int i = 0; i < MAX_SEARCH_DEPTH; ++i)
-        nodes[i].reset();
+        search_stack[i].reset();
 }
 
 inline bool stop_search(const ThreadData &td) { return td.stop || td.search_limiter.time_over(td.nodes_searched); }
@@ -117,7 +117,7 @@ ScoreType iterative_deepening(ThreadData &td) {
             break;
 
         if (td.report)
-            print_search_info(depth, score, td.nodes[0].pv_list, td);
+            print_search_info(depth, score, td.search_stack[0].pv_list, td);
 
         if (depth > 5)
             td.search_limiter.update(td, pv_stability, score_stability);
@@ -182,10 +182,10 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
     ++td.nodes_searched;
 
     const bool pv_node = alpha != beta - 1;
-    const Move excluded_move = td.nodes[ply].excluded_move;
+    const Move excluded_move = td.search_stack[ply].excluded_move;
     const bool singular_search = !excluded_move.is_none();
     Position &position = td.position;
-    NodeData &node = td.nodes[ply];
+    SearchStackEntry &node = td.search_stack[ply];
 
     // Early return conditions
     bool root = ply == 0;
@@ -246,24 +246,24 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
     }
 
     // Clean excluded and killer moves for the next ply
-    td.nodes[ply + 1].excluded_move = Move::none();
+    td.search_stack[ply + 1].excluded_move = Move::none();
     td.search_history.clear_killers(ply + 1);
 
     bool improving = [&]() -> bool {
         if (!in_check) {
-            if (ply >= 2 && td.nodes[ply - 2].static_eval != SCORE_NONE)
-                return node.static_eval > td.nodes[ply - 2].static_eval;
-            if (ply >= 4 && td.nodes[ply - 4].static_eval != SCORE_NONE)
-                return node.static_eval > td.nodes[ply - 4].static_eval;
+            if (ply >= 2 && td.search_stack[ply - 2].static_eval != SCORE_NONE)
+                return node.static_eval > td.search_stack[ply - 2].static_eval;
+            if (ply >= 4 && td.search_stack[ply - 4].static_eval != SCORE_NONE)
+                return node.static_eval > td.search_stack[ply - 4].static_eval;
         }
         return false;
     }();
 
     // Forward pruning methods
     if (!in_check && !pv_node && !root && !singular_search) {
-        if (ply >= 1 && td.nodes[ply - 1].static_eval != SCORE_NONE) {
-            ScoreType eval_delta = node.static_eval + td.nodes[ply - 1].static_eval;
-            CounterType reduction = td.nodes[ply - 1].reduction;
+        if (ply >= 1 && td.search_stack[ply - 1].static_eval != SCORE_NONE) {
+            ScoreType eval_delta = node.static_eval + td.search_stack[ply - 1].static_eval;
+            CounterType reduction = td.search_stack[ply - 1].reduction;
 
             // Hindsight extension
             if (reduction > 1 && eval_delta < 0)
@@ -411,9 +411,9 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
 
             td.tt.prefetch(position.hash());
 
-            td.nodes[ply].excluded_move = ttmove;
+            td.search_stack[ply].excluded_move = ttmove;
             ScoreType singular_score = negamax(singular_beta - 1, singular_beta, singular_depth, ply, cutnode, td);
-            td.nodes[ply].excluded_move = Move::none();
+            td.search_stack[ply].excluded_move = Move::none();
 
             if (singular_score < singular_beta) {
                 extension = 1;
@@ -444,7 +444,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
         ++moves_searched;
 
         int64_t nodes_before_search = td.nodes_searched;
-        td.nodes[ply + 1].pv_list.clear();
+        td.search_stack[ply + 1].pv_list.clear();
         ScoreType score;
         if (moves_searched == 1) {
             score = -negamax(-beta, -alpha, new_depth, ply + 1, false, td);
@@ -474,9 +474,9 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
             const int reduction = scaled_reduction / 1024;
             const int lmr_depth = std::min(std::max(new_depth - reduction, 1), new_depth);
 
-            td.nodes[ply].reduction = reduction;
+            td.search_stack[ply].reduction = reduction;
             score = -negamax(-alpha - 1, -alpha, lmr_depth, ply + 1, true, td);
-            td.nodes[ply].reduction = 0;
+            td.search_stack[ply].reduction = 0;
 
             if (score > alpha && lmr_depth < new_depth) {
                 new_depth += score > best_score + lmr_deeper_margin() + lmr_deeper_depth_factor() * new_depth;
@@ -500,7 +500,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
             if (score > alpha) {
                 best_move = move;
                 if (pv_node)
-                    node.pv_list.update(best_move, td.nodes[ply + 1].pv_list);
+                    node.pv_list.update(best_move, td.search_stack[ply + 1].pv_list);
 
                 if (score >= beta) { // Failed high
                     td.search_history.update_history(td, best_move, depth, ply, quiets_tried, tacticals_tried);
@@ -542,7 +542,7 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, CounterType ply, ThreadDat
         return position.in_check() ? 0 : td.nnue.eval(position);
 
     bool pv_node = alpha != beta - 1;
-    NodeData &node = td.nodes[ply];
+    SearchStackEntry &node = td.search_stack[ply];
     TTEntry tte;
     bool tthit = td.tt.probe(position, tte);
     Move ttmove = tthit ? tte.best_move() : Move::none();

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -70,7 +70,6 @@ ThreadData::ThreadData() {
 void ThreadData::reset_search_parameters() {
     best_move = Move::none();
     stop = true;
-    ply = 0;
     nodes_searched = -1; // Avoid counting the root
     std::memset(node_table, 0, sizeof(node_table));
     search_limiter.init();
@@ -150,7 +149,7 @@ ScoreType aspiration(const CounterType &depth, const ScoreType prev_score, Threa
     int score = SCORE_NONE;
     CounterType curr_depth = depth;
     while (true) {
-        ScoreType curr_score = negamax(alpha, beta, curr_depth, false, td);
+        ScoreType curr_score = negamax(alpha, beta, curr_depth, 0, false, td);
 
         if (stop_search(td))
             break;
@@ -174,31 +173,32 @@ ScoreType aspiration(const CounterType &depth, const ScoreType prev_score, Threa
     return score;
 }
 
-ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool cutnode, ThreadData &td) {
+ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterType ply, const bool cutnode,
+                  ThreadData &td) {
     if (stop_search(td)) // Out of time
         return -MAX_SCORE;
     else if (depth <= 0)
-        return quiescence(alpha, beta, td);
+        return quiescence(alpha, beta, ply, td);
     ++td.nodes_searched;
 
     const bool pv_node = alpha != beta - 1;
-    const Move excluded_move = td.nodes[td.ply].excluded_move;
+    const Move excluded_move = td.nodes[ply].excluded_move;
     const bool singular_search = !excluded_move.is_none();
     Position &position = td.position;
-    NodeData &node = td.nodes[td.ply];
+    NodeData &node = td.nodes[ply];
 
     // Early return conditions
-    bool root = td.ply == 0;
+    bool root = ply == 0;
     if (!root) {
         if (position.is_draw())
             return 0;
 
-        if (td.ply >= MAX_SEARCH_DEPTH - 1)
+        if (ply >= MAX_SEARCH_DEPTH - 1)
             return position.in_check() ? 0 : td.nnue.eval(position);
 
         // Mate distance pruning
-        alpha = std::max(alpha, static_cast<ScoreType>(-MATE_SCORE + td.ply));
-        beta = std::min(beta, static_cast<ScoreType>(MATE_SCORE - td.ply - 1));
+        alpha = std::max(alpha, static_cast<ScoreType>(-MATE_SCORE + ply));
+        beta = std::min(beta, static_cast<ScoreType>(MATE_SCORE - ply - 1));
         if (alpha >= beta)
             return alpha;
     }
@@ -226,7 +226,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
     bool in_check = position.in_check();
     ScoreType eval, raw_eval;
-    ScoreType correction_value = td.correction_history.correction(td);
+    ScoreType correction_value = td.correction_history.correction(td, ply);
     ScoreType complexity = std::abs(correction_value);
     if (in_check) {
         eval = node.static_eval = raw_eval = SCORE_NONE;
@@ -245,25 +245,25 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
         td.tt.store(position.hash(), 0, Move::none(), SCORE_NONE, raw_eval, BOUND_EMPTY, ttpv, td.tt.age());
     }
 
-    // Clean killer moves for the next ply
-    td.nodes[td.ply + 1].excluded_move = Move::none();
-    td.search_history.clear_killers(td.ply + 1);
+    // Clean excluded and killer moves for the next ply
+    td.nodes[ply + 1].excluded_move = Move::none();
+    td.search_history.clear_killers(ply + 1);
 
     bool improving = [&]() -> bool {
         if (!in_check) {
-            if (td.ply >= 2 && td.nodes[td.ply - 2].static_eval != SCORE_NONE)
-                return node.static_eval > td.nodes[td.ply - 2].static_eval;
-            if (td.ply >= 4 && td.nodes[td.ply - 4].static_eval != SCORE_NONE)
-                return node.static_eval > td.nodes[td.ply - 4].static_eval;
+            if (ply >= 2 && td.nodes[ply - 2].static_eval != SCORE_NONE)
+                return node.static_eval > td.nodes[ply - 2].static_eval;
+            if (ply >= 4 && td.nodes[ply - 4].static_eval != SCORE_NONE)
+                return node.static_eval > td.nodes[ply - 4].static_eval;
         }
         return false;
     }();
 
     // Forward pruning methods
     if (!in_check && !pv_node && !root && !singular_search) {
-        if (td.ply >= 1 && td.nodes[td.ply - 1].static_eval != SCORE_NONE) {
-            ScoreType eval_delta = node.static_eval + td.nodes[td.ply - 1].static_eval;
-            CounterType reduction = td.nodes[td.ply - 1].reduction;
+        if (ply >= 1 && td.nodes[ply - 1].static_eval != SCORE_NONE) {
+            ScoreType eval_delta = node.static_eval + td.nodes[ply - 1].static_eval;
+            CounterType reduction = td.nodes[ply - 1].reduction;
 
             // Hindsight extension
             if (reduction > 1 && eval_delta < 0)
@@ -288,7 +288,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
         // Razoring heuristic
         if (depth <= razoring_max_depth() && node.static_eval + razoring_mult() * depth < alpha) {
-            const ScoreType razor_score = quiescence(alpha, beta, td);
+            const ScoreType razor_score = quiescence(alpha, beta, ply, td);
             if (razor_score <= alpha)
                 return razor_score;
         }
@@ -309,11 +309,9 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
             make_null_move(td);
             td.tt.prefetch(position.hash());
-            ++td.ply;
             node.curr_pmove = PieceMove::none();
-            ScoreType null_score = -negamax(-beta, -beta + 1, depth - reduction, !cutnode, td);
+            ScoreType null_score = -negamax(-beta, -beta + 1, depth - reduction, ply + 1, !cutnode, td);
             unmake_null_move(td);
-            --td.ply;
 
             if (null_score >= beta)
                 return null_score;
@@ -323,7 +321,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
         ScoreType pc_beta = std::min(beta + probcut_margin(), MATE_FOUND - 1);
         if (depth >= probcut_min_depth() && std::abs(beta) < MATE_FOUND &&
             (!tthit || ttdepth < depth - 3 || (ttscore != SCORE_NONE && ttscore >= pc_beta))) {
-            MovePicker move_picker(ttmove, td, PROBCUT, pc_beta - node.static_eval);
+            MovePicker move_picker(ttmove, td, ply, PROBCUT, pc_beta - node.static_eval);
             while (true) { // iterate through all moves in move_picker
                 const Move move = move_picker.next_move(true);
                 if (!move) { // no more moves
@@ -337,15 +335,12 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                 node.curr_pmove = {move, position.piece_at(move.from())};
                 make_move(td, move);
 
-                ++td.ply;
-
                 td.tt.prefetch(position.hash());
 
-                int pc_score = -quiescence(-pc_beta, -pc_beta + 1, td);
+                int pc_score = -quiescence(-pc_beta, -pc_beta + 1, ply + 1, td);
                 if (pc_score >= pc_beta)
-                    pc_score = -negamax(-pc_beta, -pc_beta + 1, depth - 4, !cutnode, td);
+                    pc_score = -negamax(-pc_beta, -pc_beta + 1, depth - 4, ply + 1, !cutnode, td);
 
-                --td.ply;
                 unmake_move(td, move);
 
                 if (pc_score >= pc_beta) {
@@ -362,7 +357,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
     int moves_searched = 0;
 
     bool skip_quiets = false;
-    MovePicker move_picker(ttmove, td, SEARCH);
+    MovePicker move_picker(ttmove, td, ply, SEARCH);
     PieceMoveList quiets_tried, tacticals_tried;
     while (true) { // iterate through all moves in move_picker
         const Move move = move_picker.next_move(skip_quiets);
@@ -396,7 +391,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
             // Quiet History Pruning
             if (lmr_scaled_depth <= history_pruning_max_depth_scaled() && move.is_quiet() &&
-                td.search_history.get_history(td, move) <
+                td.search_history.get_history(td, move, ply) <
                     quiet_hist_pruning_factor() * depth + quiet_hist_pruning_base()) {
                 skip_quiets = true;
                 continue;
@@ -416,9 +411,9 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
             td.tt.prefetch(position.hash());
 
-            td.nodes[td.ply].excluded_move = ttmove;
-            ScoreType singular_score = negamax(singular_beta - 1, singular_beta, singular_depth, cutnode, td);
-            td.nodes[td.ply].excluded_move = Move::none();
+            td.nodes[ply].excluded_move = ttmove;
+            ScoreType singular_score = negamax(singular_beta - 1, singular_beta, singular_depth, ply, cutnode, td);
+            td.nodes[ply].excluded_move = Move::none();
 
             if (singular_score < singular_beta) {
                 extension = 1;
@@ -446,14 +441,13 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
         else
             tacticals_tried.push(node.curr_pmove);
 
-        ++td.ply;
         ++moves_searched;
 
         int64_t nodes_before_search = td.nodes_searched;
-        td.nodes[td.ply].pv_list.clear();
+        td.nodes[ply + 1].pv_list.clear();
         ScoreType score;
         if (moves_searched == 1) {
-            score = -negamax(-beta, -alpha, new_depth, false, td);
+            score = -negamax(-beta, -alpha, new_depth, ply + 1, false, td);
         } else {
             int scaled_reduction = 0;
             // Late Move Reduction
@@ -467,7 +461,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                 scaled_reduction += cutnode * lmr_cutnode_delta();          // Reduce cutnodes more
 
                 // Reduce less if move is killer
-                scaled_reduction -= td.search_history.is_killer(move, td.ply - 1) * lmr_killer_delta();
+                scaled_reduction -= td.search_history.is_killer(move, ply) * lmr_killer_delta();
 
                 // Reduce less if this move is or was a principal variation
                 scaled_reduction -= ttpv * lmr_ttpv_delta();
@@ -480,23 +474,22 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             const int reduction = scaled_reduction / 1024;
             const int lmr_depth = std::min(std::max(new_depth - reduction, 1), new_depth);
 
-            td.nodes[td.ply - 1].reduction = reduction;
-            score = -negamax(-alpha - 1, -alpha, lmr_depth, true, td);
-            td.nodes[td.ply - 1].reduction = 0;
+            td.nodes[ply].reduction = reduction;
+            score = -negamax(-alpha - 1, -alpha, lmr_depth, ply + 1, true, td);
+            td.nodes[ply].reduction = 0;
 
             if (score > alpha && lmr_depth < new_depth) {
                 new_depth += score > best_score + lmr_deeper_margin() + lmr_deeper_depth_factor() * new_depth;
                 new_depth -= score < best_score + lmr_shallower_margin() + lmr_shallower_depth_factor() * new_depth;
 
-                score = -negamax(-alpha - 1, -alpha, new_depth, !cutnode, td);
+                score = -negamax(-alpha - 1, -alpha, new_depth, ply + 1, !cutnode, td);
             }
 
             if (pv_node && score > alpha) {
-                score = -negamax(-beta, -alpha, new_depth, false, td);
+                score = -negamax(-beta, -alpha, new_depth, ply + 1, false, td);
             }
         }
 
-        --td.ply;
         unmake_move(td, move);
         assert(score >= -MAX_SCORE);
         td.node_table[move.from_and_to()] += td.nodes_searched - nodes_before_search;
@@ -507,10 +500,10 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             if (score > alpha) {
                 best_move = move;
                 if (pv_node)
-                    node.pv_list.update(best_move, td.nodes[td.ply + 1].pv_list);
+                    node.pv_list.update(best_move, td.nodes[ply + 1].pv_list);
 
                 if (score >= beta) { // Failed high
-                    td.search_history.update_history(td, best_move, depth, quiets_tried, tacticals_tried);
+                    td.search_history.update_history(td, best_move, depth, ply, quiets_tried, tacticals_tried);
                     break;
                 }
                 alpha = score; // Only update alpha if don't failed high
@@ -520,14 +513,14 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
     if (moves_searched == 0) { // handle positions under stalemate or checkmate,
                                // i.e. positions with no legal moves to be made
-        return position.in_check() ? -MATE_SCORE + td.ply : 0;
+        return position.in_check() ? -MATE_SCORE + ply : 0;
     }
 
     const BoundType bound = best_score >= beta ? LOWER : (alpha != old_alpha ? EXACT : UPPER);
     if (!in_check && (best_move.is_none() || best_move.is_quiet()) &&
         (bound == EXACT || (bound == LOWER && best_score > node.static_eval) ||
          (bound == UPPER && best_score < node.static_eval))) {
-        td.correction_history.update(td, depth, best_score - node.static_eval);
+        td.correction_history.update(td, depth, ply, best_score - node.static_eval);
     }
 
     if (!stop_search(td) && !singular_search) {
@@ -538,18 +531,18 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
     return best_score;
 }
 
-ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
+ScoreType quiescence(ScoreType alpha, ScoreType beta, CounterType ply, ThreadData &td) {
     ++td.nodes_searched;
     Position &position = td.position;
     if (stop_search(td))
         return -MAX_SCORE;
     else if (position.is_draw())
         return 0;
-    else if (td.ply >= MAX_SEARCH_DEPTH - 1)
+    else if (ply >= MAX_SEARCH_DEPTH - 1)
         return position.in_check() ? 0 : td.nnue.eval(position);
 
     bool pv_node = alpha != beta - 1;
-    NodeData &node = td.nodes[td.ply];
+    NodeData &node = td.nodes[ply];
     TTEntry tte;
     bool tthit = td.tt.probe(position, tte);
     Move ttmove = tthit ? tte.best_move() : Move::none();
@@ -569,7 +562,7 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
         best_score = -MAX_SCORE;
     } else if (tthit) {
         raw_eval = tteval != SCORE_NONE ? tteval : td.nnue.eval(position);
-        best_score = node.static_eval = adjust_eval(position, raw_eval, td.correction_history.correction(td));
+        best_score = node.static_eval = adjust_eval(position, raw_eval, td.correction_history.correction(td, ply));
 
         if (ttscore != SCORE_NONE && (ttbound == EXACT || (ttbound == UPPER && ttscore < best_score) ||
                                       (ttbound == LOWER && ttscore > best_score))) {
@@ -578,7 +571,7 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
 
     } else {
         raw_eval = td.nnue.eval(position);
-        best_score = node.static_eval = adjust_eval(position, raw_eval, td.correction_history.correction(td));
+        best_score = node.static_eval = adjust_eval(position, raw_eval, td.correction_history.correction(td, ply));
         td.tt.store(position.hash(), 0, Move::none(), SCORE_NONE, raw_eval, BOUND_EMPTY, ttpv, td.tt.age());
     }
 
@@ -588,7 +581,7 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
     alpha = std::max(alpha, best_score);
 
     Move best_move = Move::none();
-    MovePicker move_picker((tthit ? ttmove : Move::none()), td, QSEARCH);
+    MovePicker move_picker((tthit ? ttmove : Move::none()), td, ply, QSEARCH);
     int moves_searched = 0;
     while (true) { // iterate through all moves in move_picker
         const Move move = move_picker.next_move(!in_check);
@@ -611,9 +604,7 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
         td.tt.prefetch(position.hash());
 
         ++moves_searched;
-        ++td.ply;
-        ScoreType score = -quiescence(-beta, -alpha, td);
-        --td.ply;
+        ScoreType score = -quiescence(-beta, -alpha, ply + 1, td);
 
         unmake_move(td, move);
 
@@ -630,7 +621,7 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
     }
 
     if (moves_searched == 0 && in_check) {
-        return -MATE_SCORE + td.ply;
+        return -MATE_SCORE + ply;
     }
 
     BoundType bound = best_score >= beta ? LOWER : UPPER;

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -35,17 +35,6 @@
 #include "search/tt.h"
 #include "uci/tune.h"
 
-ScoreType normalize_score(ScoreType score) {
-    // TODO scores should be normalize such that +100/-100 means 50% chance of wining or losing
-    return score / 2;
-}
-
-static bool is_mate(const ScoreType score) { return score > MATE_FOUND; }
-
-static bool is_mated(const ScoreType score) { return score < -MATE_FOUND; }
-
-static bool is_decisive(const ScoreType score) { return is_mate(score) || is_mated(score); }
-
 static void print_search_info(const CounterType &depth, const ScoreType &eval, const PvList &pv_list,
                               const ThreadData &td) {
     std::cout << "info depth " << depth;

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -254,12 +254,13 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
     td.search_history.clear_killers(ply + 1);
 
     const bool improving = [&]() -> bool {
-        if (!in_check) {
-            if (ply >= 2 && td.search_stack[ply - 2].static_eval != SCORE_NONE)
-                return node.static_eval > td.search_stack[ply - 2].static_eval;
-            if (ply >= 4 && td.search_stack[ply - 4].static_eval != SCORE_NONE)
-                return node.static_eval > td.search_stack[ply - 4].static_eval;
-        }
+        if (in_check)
+            return false;
+        if (ply >= 2 && td.search_stack[ply - 2].static_eval != SCORE_NONE)
+            return node.static_eval > td.search_stack[ply - 2].static_eval;
+        if (ply >= 4 && td.search_stack[ply - 4].static_eval != SCORE_NONE)
+            return node.static_eval > td.search_stack[ply - 4].static_eval;
+
         return false;
     }();
 

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -43,9 +43,11 @@ static void report_search_info(const CounterType &depth, const ScoreType &eval, 
     } else {
         std::cout << " score cp " << normalize_score(eval);
     }
+
     // Add 1 to time_passed() to avoid division by 0
     std::cout << " time " << td.search_limiter.time_passed() << " nodes " << td.nodes_searched << " nps "
               << td.nodes_searched * 1000 / (td.search_limiter.time_passed() + 1) << " pv ";
+
     pv_list.print(td.chess960, td.position.castle_rooks_bb());
     std::cout << std::endl;
 }
@@ -83,7 +85,7 @@ ScoreType iterative_deepening(ThreadData &td) {
     CounterType pv_stability = 0;
     CounterType score_stability = 0;
     for (CounterType depth = 1; depth <= std::min(td.search_limiter.max_depth(), MAX_SEARCH_DEPTH - 1); ++depth) {
-        ScoreType score = aspiration(depth, past_score, td);
+        const ScoreType score = aspiration(depth, past_score, td);
         if (stop_search(td)) // Search did not finished completely
             break;
 
@@ -123,7 +125,7 @@ ScoreType iterative_deepening(ThreadData &td) {
 
     td.stop = true;
     td.best_move = best_move; // A partial search would mess this up
-    td.tt.update_age();       // Update tt age
+    td.tt.update_age();
 
     if (td.report)
         report_search_result(td, best_move);
@@ -143,7 +145,7 @@ ScoreType aspiration(const CounterType &depth, const ScoreType prev_score, Threa
     int score = SCORE_NONE;
     CounterType curr_depth = depth;
     while (true) {
-        ScoreType curr_score = negamax(alpha, beta, curr_depth, 0, false, td);
+        const ScoreType curr_score = negamax(alpha, beta, curr_depth, 0, false, td);
 
         if (stop_search(td))
             break;
@@ -152,10 +154,10 @@ ScoreType aspiration(const CounterType &depth, const ScoreType prev_score, Threa
 
         if (curr_score <= alpha) {
             beta = (alpha + beta) / 2;
-            alpha = std::max(static_cast<int>(-MAX_SCORE), alpha - delta);
+            alpha = std::max<int>(-MAX_SCORE, alpha - delta);
             curr_depth = depth;
         } else if (curr_score >= beta) {
-            beta = std::min(static_cast<int>(MAX_SCORE), beta + delta);
+            beta = std::min<int>(MAX_SCORE, beta + delta);
             curr_depth = std::max(1, curr_depth - 1);
         } else {
             break;
@@ -182,7 +184,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
     SearchStackEntry &node = td.search_stack[ply];
 
     // Early return conditions
-    bool root = ply == 0;
+    const bool root = ply == 0;
     if (!root) {
         if (position.is_draw())
             return 0;
@@ -191,25 +193,33 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
             return position.in_check() ? 0 : td.nnue.eval(position);
 
         // Mate distance pruning
-        alpha = std::max(alpha, static_cast<ScoreType>(-MATE_SCORE + ply));
-        beta = std::min(beta, static_cast<ScoreType>(MATE_SCORE - ply - 1));
+        alpha = std::max<ScoreType>(alpha, (-MATE_SCORE + ply));
+        beta = std::min<ScoreType>(beta, (MATE_SCORE - ply - 1));
         if (alpha >= beta)
             return alpha;
     }
 
     // Transposition table probe
     TTEntry tte;
-    bool tthit = td.tt.probe(position, tte);
-    tthit = tthit && !singular_search; // Don't use ttentry result if in singular search
+
+    const bool tthit = !singular_search && td.tt.probe(position, tte); // Don't use ttentry result if in singular search
+
     // Extraction data from ttentry if tthit
-    Move ttmove = (tthit ? tte.best_move() : Move::none());
-    ScoreType ttscore = tthit ? tte.score() : SCORE_NONE;
-    ScoreType tteval = tthit ? tte.eval() : SCORE_NONE;
-    IndexType ttbound = tthit ? tte.bound() : static_cast<IndexType>(BOUND_EMPTY);
-    IndexType ttdepth = tthit ? tte.depth() : 0;
+    const Move ttmove = (tthit ? tte.best_move() : Move::none());
+    const ScoreType ttscore = tthit ? tte.score() : SCORE_NONE;
+    const ScoreType tteval = tthit ? tte.eval() : SCORE_NONE;
+    const IndexType ttbound = tthit ? tte.bound() : static_cast<IndexType>(BOUND_EMPTY);
+    const IndexType ttdepth = tthit ? tte.depth() : 0;
     const bool ttpv = pv_node || (tthit && tte.was_pv());
-    if (!pv_node && !singular_search && tthit && ttdepth >= depth && (ttscore <= alpha || cutnode) &&
-        (ttbound == EXACT || (ttbound == UPPER && ttscore <= alpha) || (ttbound == LOWER && ttscore >= beta))) {
+    if (!pv_node                                      //
+        && !singular_search                           //
+        && tthit                                      //
+        && ttdepth >= depth                           //
+        && (ttscore <= alpha || cutnode)              //
+        && (ttbound == EXACT                          //
+            || (ttbound == UPPER && ttscore <= alpha) //
+            || (ttbound == LOWER && ttscore >= beta)) //
+    ) {
         return ttscore;
     }
 
@@ -218,10 +228,10 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
         depth -= 1;
     }
 
-    bool in_check = position.in_check();
+    const bool in_check = position.in_check();
     ScoreType eval, raw_eval;
-    ScoreType correction_value = td.correction_history.correction(td, ply);
-    ScoreType complexity = std::abs(correction_value);
+    const ScoreType correction_value = td.correction_history.correction(td, ply);
+    const ScoreType complexity = std::abs(correction_value);
     if (in_check) {
         eval = node.static_eval = raw_eval = SCORE_NONE;
     } else if (singular_search) {
@@ -243,7 +253,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
     td.search_stack[ply + 1].excluded_move = Move::none();
     td.search_history.clear_killers(ply + 1);
 
-    bool improving = [&]() -> bool {
+    const bool improving = [&]() -> bool {
         if (!in_check) {
             if (ply >= 2 && td.search_stack[ply - 2].static_eval != SCORE_NONE)
                 return node.static_eval > td.search_stack[ply - 2].static_eval;
@@ -256,8 +266,8 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
     // Forward pruning methods
     if (!in_check && !pv_node && !root && !singular_search) {
         if (ply >= 1 && td.search_stack[ply - 1].static_eval != SCORE_NONE) {
-            ScoreType eval_delta = node.static_eval + td.search_stack[ply - 1].static_eval;
-            CounterType reduction = td.search_stack[ply - 1].reduction;
+            const ScoreType eval_delta = node.static_eval + td.search_stack[ply - 1].static_eval;
+            const CounterType reduction = td.search_stack[ply - 1].reduction;
 
             // Hindsight extension
             if (reduction > 1 && eval_delta < 0)
@@ -288,23 +298,24 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
         }
 
         // Null move pruning (NMP)
-        ScoreType nmp_beta_margin = [&]() {
+        const ScoreType nmp_beta_margin = [&]() {
             int margin = nmp_beta_base_margin();
             margin -= nmp_beta_improving_margin() * improving;
             margin -= nmp_beta_depth_factor() * depth / 128;
             return std::max(margin, 0);
         }();
-        if (!position.last_was_null()   //
-            && depth >= nmp_min_depth() //
-            && position.has_non_pawns() //
-            && eval >= beta             //
-            && node.static_eval >= beta + nmp_beta_margin) {
+        if (!position.last_was_null()                     //
+            && depth >= nmp_min_depth()                   //
+            && position.has_non_pawns()                   //
+            && eval >= beta                               //
+            && node.static_eval >= beta + nmp_beta_margin //
+        ) {
             const int reduction = (nmp_base_reduction() + depth * nmp_depth_factor()) / 64;
 
             make_null_move(td);
             td.tt.prefetch(position.hash());
             node.curr_pmove = PieceMove::none();
-            ScoreType null_score = -negamax(-beta, -beta + 1, depth - reduction, ply + 1, !cutnode, td);
+            const ScoreType null_score = -negamax(-beta, -beta + 1, depth - reduction, ply + 1, !cutnode, td);
             unmake_null_move(td);
 
             if (null_score >= beta)
@@ -312,9 +323,11 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
         }
 
         // Prob Cut
-        ScoreType pc_beta = std::min(beta + probcut_margin(), MATE_FOUND - 1);
-        if (depth >= probcut_min_depth() && !is_decisive(beta) &&
-            (!tthit || ttdepth < depth - 3 || (ttscore != SCORE_NONE && ttscore >= pc_beta))) {
+        const ScoreType pc_beta = std::min(beta + probcut_margin(), MATE_FOUND - 1);
+        if (depth >= probcut_min_depth()                                                        //
+            && !is_decisive(beta)                                                               //
+            && (!tthit || ttdepth < depth - 3 || (ttscore != SCORE_NONE && ttscore >= pc_beta)) //
+        ) {
             MovePicker move_picker(ttmove, td, ply, PROBCUT, pc_beta - node.static_eval);
             while (true) { // iterate through all moves in move_picker
                 const Move move = move_picker.next_move(true);
@@ -347,7 +360,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
 
     Move best_move = Move::none();
     ScoreType best_score = -MAX_SCORE;
-    ScoreType old_alpha = alpha;
+    BoundType bound = UPPER;
     int moves_searched = 0;
 
     bool skip_quiets = false;
@@ -375,7 +388,11 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
 
             // Quiet Futility pruning
             const ScoreType futility_value = node.static_eval + fp_margin() + fp_depth_factor() * lmr_depth;
-            if (!in_check && move.is_quiet() && lmr_scaled_depth <= fp_max_depth() && futility_value <= alpha) {
+            if (!in_check                             //
+                && move.is_quiet()                    //
+                && lmr_scaled_depth <= fp_max_depth() //
+                && futility_value <= alpha            //
+            ) {
                 if (!is_decisive(best_score) && best_score < futility_value) {
                     best_score = futility_value;
                 }
@@ -384,36 +401,44 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
             }
 
             // Quiet History Pruning
-            if (lmr_scaled_depth <= history_pruning_max_depth_scaled() && move.is_quiet() &&
-                td.search_history.get_history(td, move, ply) <
-                    quiet_hist_pruning_factor() * depth + quiet_hist_pruning_base()) {
+            if (lmr_scaled_depth <= history_pruning_max_depth_scaled() //
+                && move.is_quiet()                                     //
+                && td.search_history.get_history(td, move, ply) <
+                       quiet_hist_pruning_factor() * depth + quiet_hist_pruning_base() //
+            ) {
                 skip_quiets = true;
                 continue;
             }
 
             const int see_margin = see_noisy_pruning_factor() * lmr_depth * lmr_depth;
-            if (move_picker.picker_stage() >= PICK_BAD_NOISY && !SEE(position, move, see_margin))
+            if (move_picker.picker_stage() >= PICK_BAD_NOISY && !SEE(position, move, see_margin)) {
                 continue;
+            }
         }
 
         // Extensions
         int extension = 0;
-        if (!root && depth >= singular_extension_min_depth() && move == ttmove && ttdepth > depth - 4 &&
-            move != excluded_move && ttbound == LOWER) {
-            ScoreType singular_beta = ttscore - depth * singular_extension_depth_factor() / 16;
-            ScoreType singular_depth = (depth - 1) / 2;
+        if (!root                                      //
+            && depth >= singular_extension_min_depth() //
+            && move == ttmove                          //
+            && ttdepth > depth - 4                     //
+            && move != excluded_move                   //
+            && ttbound == LOWER                        //
+        ) {
+            const ScoreType singular_beta = ttscore - depth * singular_extension_depth_factor() / 16;
+            const ScoreType singular_depth = (depth - 1) / 2;
 
             td.tt.prefetch(position.hash());
 
             td.search_stack[ply].excluded_move = ttmove;
-            ScoreType singular_score = negamax(singular_beta - 1, singular_beta, singular_depth, ply, cutnode, td);
+            const ScoreType singular_score =
+                negamax(singular_beta - 1, singular_beta, singular_depth, ply, cutnode, td);
             td.search_stack[ply].excluded_move = Move::none();
 
             if (singular_score < singular_beta) {
                 extension = 1;
-
-                if (!pv_node && singular_score < singular_beta - double_extension_margin())
-                    extension = 2 + (singular_score < singular_beta - triple_ext_margin());
+                extension += !pv_node && singular_score < singular_beta - double_extension_margin();
+                extension += !pv_node && singular_score < singular_beta - triple_ext_margin();
             } else if (singular_score >= beta) { // Multi-Cut
                 return singular_score;
             } else if (ttscore >= beta) {
@@ -437,7 +462,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
 
         ++moves_searched;
 
-        int64_t nodes_before_search = td.nodes_searched;
+        const int64_t nodes_before_search = td.nodes_searched;
         td.search_stack[ply + 1].pv_list.clear();
         ScoreType score;
         if (moves_searched == 1) {
@@ -493,27 +518,30 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
 
             if (score > alpha) {
                 best_move = move;
-                if (pv_node)
+                if (pv_node) {
                     node.pv_list.update(best_move, td.search_stack[ply + 1].pv_list);
+                }
 
                 if (score >= beta) { // Failed high
                     td.search_history.update_history(td, best_move, depth, ply, quiets_tried, tacticals_tried);
+                    bound = LOWER;
                     break;
                 }
                 alpha = score; // Only update alpha if don't failed high
+                bound = EXACT;
             }
         }
     }
 
-    if (moves_searched == 0) { // handle positions under stalemate or checkmate,
-                               // i.e. positions with no legal moves to be made
+    if (moves_searched == 0) { // handle positions under stalemate or checkmate
         return position.in_check() ? -MATE_SCORE + ply : 0;
     }
 
-    const BoundType bound = best_score >= beta ? LOWER : (alpha != old_alpha ? EXACT : UPPER);
-    if (!in_check && (best_move.is_none() || best_move.is_quiet()) &&
-        (bound == EXACT || (bound == LOWER && best_score > node.static_eval) ||
-         (bound == UPPER && best_score < node.static_eval))) {
+    if (!in_check                                        //
+        && (best_move.is_none() || best_move.is_quiet()) //
+        && (bound == EXACT || (bound == LOWER && best_score > node.static_eval) ||
+            (bound == UPPER && best_score < node.static_eval)) //
+    ) {
         td.correction_history.update(td, depth, ply, best_score - node.static_eval);
     }
 
@@ -535,21 +563,27 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, CounterType ply, ThreadDat
     else if (ply >= MAX_SEARCH_DEPTH - 1)
         return position.in_check() ? 0 : td.nnue.eval(position);
 
-    bool pv_node = alpha != beta - 1;
+    const bool pv_node = alpha != beta - 1;
     SearchStackEntry &node = td.search_stack[ply];
+
     TTEntry tte;
-    bool tthit = td.tt.probe(position, tte);
-    Move ttmove = tthit ? tte.best_move() : Move::none();
-    ScoreType ttscore = tthit ? tte.score() : SCORE_NONE;
-    ScoreType tteval = tthit ? tte.eval() : SCORE_NONE;
-    IndexType ttbound = tthit ? tte.bound() : static_cast<IndexType>(BOUND_EMPTY);
+    const bool tthit = td.tt.probe(position, tte);
+    const Move ttmove = tthit ? tte.best_move() : Move::none();
+    const ScoreType ttscore = tthit ? tte.score() : SCORE_NONE;
+    const ScoreType tteval = tthit ? tte.eval() : SCORE_NONE;
+    const IndexType ttbound = tthit ? tte.bound() : static_cast<IndexType>(BOUND_EMPTY);
     const bool ttpv = pv_node || (tthit && tte.was_pv());
-    if (!pv_node && tthit && ttscore != SCORE_NONE &&
-        (ttbound == EXACT || (ttbound == UPPER && ttscore <= alpha) || (ttbound == LOWER && ttscore >= beta))) {
+    if (!pv_node                                      //
+        && tthit                                      //
+        && ttscore != SCORE_NONE                      //
+        && (ttbound == EXACT                          //
+            || (ttbound == UPPER && ttscore <= alpha) //
+            || (ttbound == LOWER && ttscore >= beta)) //
+    ) {
         return ttscore;
     }
 
-    bool in_check = position.in_check();
+    const bool in_check = position.in_check();
     ScoreType best_score, raw_eval;
     if (in_check) {
         node.static_eval = raw_eval = SCORE_NONE;
@@ -558,8 +592,11 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, CounterType ply, ThreadDat
         raw_eval = tteval != SCORE_NONE ? tteval : td.nnue.eval(position);
         best_score = node.static_eval = adjust_eval(position, raw_eval, td.correction_history.correction(td, ply));
 
-        if (ttscore != SCORE_NONE && (ttbound == EXACT || (ttbound == UPPER && ttscore < best_score) ||
-                                      (ttbound == LOWER && ttscore > best_score))) {
+        if (ttscore != SCORE_NONE                              //
+            && (ttbound == EXACT                               //
+                || (ttbound == UPPER && ttscore < best_score)  //
+                || (ttbound == LOWER && ttscore > best_score)) //
+        ) {
             best_score = ttscore;
         }
 
@@ -570,13 +607,15 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, CounterType ply, ThreadDat
     }
 
     // Stand-pat
-    if (!in_check && best_score >= beta)
+    if (!in_check && best_score >= beta) {
         return best_score;
+    }
     alpha = std::max(alpha, best_score);
 
     Move best_move = Move::none();
     MovePicker move_picker((tthit ? ttmove : Move::none()), td, ply, QSEARCH);
     int moves_searched = 0;
+    BoundType bound = UPPER;
     while (true) { // iterate through all moves in move_picker
         const Move move = move_picker.next_move(!in_check);
         if (!move) { // no more moves
@@ -588,8 +627,11 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, CounterType ply, ThreadDat
             if (moves_searched >= 3) // late move pruning
                 break;
 
-            ScoreType futility = node.static_eval + qs_futility_margin();
-            if (!in_check && futility <= alpha && !SEE(position, move, 1)) {
+            const ScoreType futility = node.static_eval + qs_futility_margin();
+            if (!in_check                  //
+                && futility <= alpha       //
+                && !SEE(position, move, 1) //
+            ) {
                 best_score = std::max(best_score, futility);
                 continue;
             }
@@ -598,17 +640,20 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, CounterType ply, ThreadDat
         td.tt.prefetch(position.hash());
 
         ++moves_searched;
-        ScoreType score = -quiescence(-beta, -alpha, ply + 1, td);
+        const ScoreType score = -quiescence(-beta, -alpha, ply + 1, td);
 
         unmake_move(td, move);
 
         if (score > best_score) {
             best_score = score;
             best_move = move;
+
             if (score > alpha) {
                 if (score >= beta) {
+                    bound = LOWER;
                     break;
                 }
+
                 alpha = score;
             }
         }
@@ -618,7 +663,6 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, CounterType ply, ThreadDat
         return -MATE_SCORE + ply;
     }
 
-    BoundType bound = best_score >= beta ? LOWER : UPPER;
     td.tt.store(position.hash(), 0, best_move, best_score, raw_eval, bound, ttpv, td.tt.age());
 
     return best_score;
@@ -628,10 +672,10 @@ bool SEE(Position &position, const Move &move, int threshold) {
     if (move.is_castle()) // Cannot win or lose material by castling
         return threshold <= 0;
 
-    Square from = move.from();
-    Square to = move.to();
-    Piece target = move.is_ep() ? WHITE_PAWN : position.piece_at(to); // piece color does not matter
-    Piece attacker = position.piece_at(from);
+    const Square from = move.from();
+    const Square to = move.to();
+    const Piece target = move.is_ep() ? WHITE_PAWN : position.piece_at(to); // piece color does not matter
+    const Piece attacker = position.piece_at(from);
 
     int score = SEE_VALUES[target] - threshold;
     if (move.is_promotion())
@@ -645,8 +689,8 @@ bool SEE(Position &position, const Move &move, int threshold) {
 
     Bitboard attackers = position.attackers(to);
     Bitboard occupancy = position.occ_bb() ^ Bitboard(from); // Removed already used attacker
-    Bitboard diagonal_attackers = position.piece_bb(BISHOP) | position.piece_bb(QUEEN);
-    Bitboard line_attackers = position.piece_bb(ROOK) | position.piece_bb(QUEEN);
+    const Bitboard diagonal_attackers = position.piece_bb(BISHOP) | position.piece_bb(QUEEN);
+    const Bitboard line_attackers = position.piece_bb(ROOK) | position.piece_bb(QUEEN);
     Color stm = static_cast<Color>(!position.stm());
 
     while (true) {
@@ -678,7 +722,7 @@ bool SEE(Position &position, const Move &move, int threshold) {
         // Add x-ray attackers, if there is any
         switch (cheapest_attacker) {
             case PAWN:
-                // Fall-through
+                [[fallthrough]];
             case BISHOP:
                 attackers |= get_piece_attacks(to, occupancy, BISHOP) & diagonal_attackers;
                 break;

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -38,7 +38,7 @@
 static void report_search_info(const CounterType &depth, const ScoreType &eval, const PvList &pv_list,
                                const ThreadData &td) {
     std::cout << "info depth " << depth;
-    if (std::abs(eval) > MATE_FOUND) {
+    if (is_decisive(eval)) {
         std::cout << " score mate " << (eval < 0 ? "-" : "") << (MATE_SCORE - std::abs(eval) + 1) / 2;
     } else {
         std::cout << " score cp " << normalize_score(eval);
@@ -313,7 +313,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
 
         // Prob Cut
         ScoreType pc_beta = std::min(beta + probcut_margin(), MATE_FOUND - 1);
-        if (depth >= probcut_min_depth() && std::abs(beta) < MATE_FOUND &&
+        if (depth >= probcut_min_depth() && !is_decisive(beta) &&
             (!tthit || ttdepth < depth - 3 || (ttscore != SCORE_NONE && ttscore >= pc_beta))) {
             MovePicker move_picker(ttmove, td, ply, PROBCUT, pc_beta - node.static_eval);
             while (true) { // iterate through all moves in move_picker
@@ -363,7 +363,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
             continue;
         }
 
-        if (!root && best_score >= -MATE_FOUND && !skip_quiets) {
+        if (!root && !is_mated(best_score) && !skip_quiets) {
             const CounterType lmr_scaled_depth =
                 depth * 1024 - LMR_TABLE[std::min(depth, 63)][std::min(moves_searched, 63)];
             const CounterType lmr_depth = lmr_scaled_depth / 1024;
@@ -584,7 +584,7 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, CounterType ply, ThreadDat
         }
         node.curr_pmove = {move, position.piece_at(move.from())};
 
-        if (best_score > -MATE_FOUND) {
+        if (!is_mated(best_score)) {
             if (moves_searched >= 3) // late move pruning
                 break;
 

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -35,8 +35,8 @@
 #include "search/tt.h"
 #include "uci/tune.h"
 
-static void print_search_info(const CounterType &depth, const ScoreType &eval, const PvList &pv_list,
-                              const ThreadData &td) {
+static void report_search_info(const CounterType &depth, const ScoreType &eval, const PvList &pv_list,
+                               const ThreadData &td) {
     std::cout << "info depth " << depth;
     if (std::abs(eval) > MATE_FOUND) {
         std::cout << " score mate " << (eval < 0 ? "-" : "") << (MATE_SCORE - std::abs(eval) + 1) / 2;
@@ -48,6 +48,11 @@ static void print_search_info(const CounterType &depth, const ScoreType &eval, c
               << td.nodes_searched * 1000 / (td.search_limiter.time_passed() + 1) << " pv ";
     pv_list.print(td.chess960, td.position.castle_rooks_bb());
     std::cout << std::endl;
+}
+
+static void report_search_result(const ThreadData &td, Move best_move) {
+    std::cout << "bestmove " << (!best_move ? "none" : best_move.to_uci(td.chess960, td.position.castle_rooks_bb()))
+              << std::endl;
 }
 
 ThreadData::ThreadData() {
@@ -106,7 +111,7 @@ ScoreType iterative_deepening(ThreadData &td) {
             break;
 
         if (td.report)
-            print_search_info(depth, score, td.search_stack[0].pv_list, td);
+            report_search_info(depth, score, td.search_stack[0].pv_list, td);
 
         if (depth > 5)
             td.search_limiter.update(td, pv_stability, score_stability);
@@ -116,13 +121,13 @@ ScoreType iterative_deepening(ThreadData &td) {
         td.search_limiter.can_stop(); // Avoids stopping before depth 1 has been searched through
     }
 
-    if (td.report)
-        std::cout << "bestmove " << (!best_move ? "none" : best_move.to_uci(td.chess960, td.position.castle_rooks_bb()))
-                  << std::endl;
-
     td.stop = true;
     td.best_move = best_move; // A partial search would mess this up
     td.tt.update_age();       // Update tt age
+
+    if (td.report)
+        report_search_result(td, best_move);
+
     return past_score;
 }
 

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -69,7 +69,6 @@ void ThreadData::reset_search_parameters() {
     nodes_searched = -1; // Avoid counting the root
     std::memset(node_table, 0, sizeof(node_table));
     search_limiter.init();
-    // TODO i dont think this is necessary
     for (int i = 0; i < MAX_SEARCH_DEPTH; ++i)
         search_stack[i].reset();
 }
@@ -163,7 +162,7 @@ ScoreType aspiration(const CounterType &depth, const ScoreType prev_score, Threa
             break;
         }
 
-        delta += delta * (aw_widening_factor() / 100.0);
+        delta += delta * aw_widening_factor() / 100;
     }
 
     return score;
@@ -173,7 +172,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
                   ThreadData &td) {
     if (stop_search(td)) // Out of time
         return -MAX_SCORE;
-    else if (depth <= 0)
+    if (depth <= 0)
         return quiescence(alpha, beta, ply, td);
     ++td.nodes_searched;
 
@@ -239,9 +238,13 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
     } else if (tthit) {
         raw_eval = tteval != SCORE_NONE ? tteval : td.nnue.eval(position);
         eval = node.static_eval = adjust_eval(position, raw_eval, correction_value);
-        if (ttscore != SCORE_NONE &&
-            (ttbound == EXACT || (ttbound == UPPER && ttscore < eval) || (ttbound == LOWER && ttscore > eval)))
+        if (ttscore != SCORE_NONE                        //
+            && (ttbound == EXACT                         //
+                || (ttbound == UPPER && ttscore < eval)  //
+                || (ttbound == LOWER && ttscore > eval)) //
+        ) {
             eval = ttscore;
+        }
 
     } else {
         raw_eval = td.nnue.eval(position);
@@ -488,8 +491,6 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterTyp
 
                 // Reduce based on correction history.
                 scaled_reduction -= complexity / lmr_corrhist_divisor();
-            } else {
-                // reduce noisy
             }
             const int reduction = scaled_reduction / 1024;
             const int lmr_depth = std::min(std::max(new_depth - reduction, 1), new_depth);

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -70,7 +70,7 @@ ThreadData::ThreadData() {
 void ThreadData::reset_search_parameters() {
     best_move = Move::none();
     stop = true;
-    height = 0;
+    ply = 0;
     nodes_searched = -1; // Avoid counting the root
     std::memset(node_table, 0, sizeof(node_table));
     search_limiter.init();
@@ -182,23 +182,23 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
     ++td.nodes_searched;
 
     const bool pv_node = alpha != beta - 1;
-    const Move excluded_move = td.nodes[td.height].excluded_move;
+    const Move excluded_move = td.nodes[td.ply].excluded_move;
     const bool singular_search = !excluded_move.is_none();
     Position &position = td.position;
-    NodeData &node = td.nodes[td.height];
+    NodeData &node = td.nodes[td.ply];
 
     // Early return conditions
-    bool root = td.height == 0;
+    bool root = td.ply == 0;
     if (!root) {
         if (position.is_draw())
             return 0;
 
-        if (td.height >= MAX_SEARCH_DEPTH - 1)
+        if (td.ply >= MAX_SEARCH_DEPTH - 1)
             return position.in_check() ? 0 : td.nnue.eval(position);
 
         // Mate distance pruning
-        alpha = std::max(alpha, static_cast<ScoreType>(-MATE_SCORE + td.height));
-        beta = std::min(beta, static_cast<ScoreType>(MATE_SCORE - td.height - 1));
+        alpha = std::max(alpha, static_cast<ScoreType>(-MATE_SCORE + td.ply));
+        beta = std::min(beta, static_cast<ScoreType>(MATE_SCORE - td.ply - 1));
         if (alpha >= beta)
             return alpha;
     }
@@ -246,24 +246,24 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
     }
 
     // Clean killer moves for the next ply
-    td.nodes[td.height + 1].excluded_move = Move::none();
-    td.search_history.clear_killers(td.height + 1);
+    td.nodes[td.ply + 1].excluded_move = Move::none();
+    td.search_history.clear_killers(td.ply + 1);
 
     bool improving = [&]() -> bool {
         if (!in_check) {
-            if (td.height >= 2 && td.nodes[td.height - 2].static_eval != SCORE_NONE)
-                return node.static_eval > td.nodes[td.height - 2].static_eval;
-            if (td.height >= 4 && td.nodes[td.height - 4].static_eval != SCORE_NONE)
-                return node.static_eval > td.nodes[td.height - 4].static_eval;
+            if (td.ply >= 2 && td.nodes[td.ply - 2].static_eval != SCORE_NONE)
+                return node.static_eval > td.nodes[td.ply - 2].static_eval;
+            if (td.ply >= 4 && td.nodes[td.ply - 4].static_eval != SCORE_NONE)
+                return node.static_eval > td.nodes[td.ply - 4].static_eval;
         }
         return false;
     }();
 
     // Forward pruning methods
     if (!in_check && !pv_node && !root && !singular_search) {
-        if (td.height >= 1 && td.nodes[td.height - 1].static_eval != SCORE_NONE) {
-            ScoreType eval_delta = node.static_eval + td.nodes[td.height - 1].static_eval;
-            CounterType reduction = td.nodes[td.height - 1].reduction;
+        if (td.ply >= 1 && td.nodes[td.ply - 1].static_eval != SCORE_NONE) {
+            ScoreType eval_delta = node.static_eval + td.nodes[td.ply - 1].static_eval;
+            CounterType reduction = td.nodes[td.ply - 1].reduction;
 
             // Hindsight extension
             if (reduction > 1 && eval_delta < 0)
@@ -309,11 +309,11 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
             make_null_move(td);
             td.tt.prefetch(position.hash());
-            ++td.height;
+            ++td.ply;
             node.curr_pmove = PieceMove::none();
             ScoreType null_score = -negamax(-beta, -beta + 1, depth - reduction, !cutnode, td);
             unmake_null_move(td);
-            --td.height;
+            --td.ply;
 
             if (null_score >= beta)
                 return null_score;
@@ -337,7 +337,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                 node.curr_pmove = {move, position.piece_at(move.from())};
                 make_move(td, move);
 
-                ++td.height;
+                ++td.ply;
 
                 td.tt.prefetch(position.hash());
 
@@ -345,7 +345,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                 if (pc_score >= pc_beta)
                     pc_score = -negamax(-pc_beta, -pc_beta + 1, depth - 4, !cutnode, td);
 
-                --td.height;
+                --td.ply;
                 unmake_move(td, move);
 
                 if (pc_score >= pc_beta) {
@@ -416,9 +416,9 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
             td.tt.prefetch(position.hash());
 
-            td.nodes[td.height].excluded_move = ttmove;
+            td.nodes[td.ply].excluded_move = ttmove;
             ScoreType singular_score = negamax(singular_beta - 1, singular_beta, singular_depth, cutnode, td);
-            td.nodes[td.height].excluded_move = Move::none();
+            td.nodes[td.ply].excluded_move = Move::none();
 
             if (singular_score < singular_beta) {
                 extension = 1;
@@ -446,11 +446,11 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
         else
             tacticals_tried.push(node.curr_pmove);
 
-        ++td.height;
+        ++td.ply;
         ++moves_searched;
 
         int64_t nodes_before_search = td.nodes_searched;
-        td.nodes[td.height].pv_list.clear();
+        td.nodes[td.ply].pv_list.clear();
         ScoreType score;
         if (moves_searched == 1) {
             score = -negamax(-beta, -alpha, new_depth, false, td);
@@ -467,7 +467,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
                 scaled_reduction += cutnode * lmr_cutnode_delta();          // Reduce cutnodes more
 
                 // Reduce less if move is killer
-                scaled_reduction -= td.search_history.is_killer(move, td.height - 1) * lmr_killer_delta();
+                scaled_reduction -= td.search_history.is_killer(move, td.ply - 1) * lmr_killer_delta();
 
                 // Reduce less if this move is or was a principal variation
                 scaled_reduction -= ttpv * lmr_ttpv_delta();
@@ -480,9 +480,9 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             const int reduction = scaled_reduction / 1024;
             const int lmr_depth = std::min(std::max(new_depth - reduction, 1), new_depth);
 
-            td.nodes[td.height - 1].reduction = reduction;
+            td.nodes[td.ply - 1].reduction = reduction;
             score = -negamax(-alpha - 1, -alpha, lmr_depth, true, td);
-            td.nodes[td.height - 1].reduction = 0;
+            td.nodes[td.ply - 1].reduction = 0;
 
             if (score > alpha && lmr_depth < new_depth) {
                 new_depth += score > best_score + lmr_deeper_margin() + lmr_deeper_depth_factor() * new_depth;
@@ -496,7 +496,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             }
         }
 
-        --td.height;
+        --td.ply;
         unmake_move(td, move);
         assert(score >= -MAX_SCORE);
         td.node_table[move.from_and_to()] += td.nodes_searched - nodes_before_search;
@@ -507,7 +507,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
             if (score > alpha) {
                 best_move = move;
                 if (pv_node)
-                    node.pv_list.update(best_move, td.nodes[td.height + 1].pv_list);
+                    node.pv_list.update(best_move, td.nodes[td.ply + 1].pv_list);
 
                 if (score >= beta) { // Failed high
                     td.search_history.update_history(td, best_move, depth, quiets_tried, tacticals_tried);
@@ -520,7 +520,7 @@ ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool
 
     if (moves_searched == 0) { // handle positions under stalemate or checkmate,
                                // i.e. positions with no legal moves to be made
-        return position.in_check() ? -MATE_SCORE + td.height : 0;
+        return position.in_check() ? -MATE_SCORE + td.ply : 0;
     }
 
     const BoundType bound = best_score >= beta ? LOWER : (alpha != old_alpha ? EXACT : UPPER);
@@ -545,11 +545,11 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
         return -MAX_SCORE;
     else if (position.is_draw())
         return 0;
-    else if (td.height >= MAX_SEARCH_DEPTH - 1)
+    else if (td.ply >= MAX_SEARCH_DEPTH - 1)
         return position.in_check() ? 0 : td.nnue.eval(position);
 
     bool pv_node = alpha != beta - 1;
-    NodeData &node = td.nodes[td.height];
+    NodeData &node = td.nodes[td.ply];
     TTEntry tte;
     bool tthit = td.tt.probe(position, tte);
     Move ttmove = tthit ? tte.best_move() : Move::none();
@@ -611,9 +611,9 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
         td.tt.prefetch(position.hash());
 
         ++moves_searched;
-        ++td.height;
+        ++td.ply;
         ScoreType score = -quiescence(-beta, -alpha, td);
-        --td.height;
+        --td.ply;
 
         unmake_move(td, move);
 
@@ -630,7 +630,7 @@ ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td) {
     }
 
     if (moves_searched == 0 && in_check) {
-        return -MATE_SCORE + td.height;
+        return -MATE_SCORE + td.ply;
     }
 
     BoundType bound = best_score >= beta ? LOWER : UPPER;

--- a/src/search/search.h
+++ b/src/search/search.h
@@ -61,7 +61,6 @@ struct ThreadData {
     SearchLimiter search_limiter;
     int64_t nodes_searched;
     int64_t node_table[64 * 64];
-    int ply;
     bool stop;
     bool datagen;
     bool report;
@@ -89,6 +88,7 @@ ScoreType normalize_score(ScoreType score);
 
 ScoreType iterative_deepening(ThreadData &td);
 ScoreType aspiration(const CounterType &depth, const ScoreType prev_score, ThreadData &td);
-ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, const bool cutnode, ThreadData &td);
-ScoreType quiescence(ScoreType alpha, ScoreType beta, ThreadData &td);
+ScoreType negamax(ScoreType alpha, ScoreType beta, CounterType depth, CounterType ply, const bool cutnode,
+                  ThreadData &td);
+ScoreType quiescence(ScoreType alpha, ScoreType beta, CounterType ply, ThreadData &td);
 bool SEE(Position &position, const Move &move, int threshold);

--- a/src/search/search.h
+++ b/src/search/search.h
@@ -61,7 +61,7 @@ struct ThreadData {
     SearchLimiter search_limiter;
     int64_t nodes_searched;
     int64_t node_table[64 * 64];
-    int height;
+    int ply;
     bool stop;
     bool datagen;
     bool report;

--- a/src/search/search.h
+++ b/src/search/search.h
@@ -33,7 +33,7 @@ constexpr int LMP_DEPTH = 32;
 extern int LMP_TABLE[2][LMP_DEPTH];
 extern int LMR_TABLE[64][64];
 
-struct NodeData {
+struct SearchStackEntry {
     PieceMove curr_pmove;
     Move excluded_move;
     CounterType reduction;
@@ -55,7 +55,7 @@ struct ThreadData {
     NNUE nnue;
     History search_history;
     CorrectionHistory correction_history;
-    NodeData nodes[MAX_SEARCH_DEPTH];
+    SearchStackEntry search_stack[MAX_SEARCH_DEPTH];
     Move best_move;
 
     SearchLimiter search_limiter;

--- a/src/search/search.h
+++ b/src/search/search.h
@@ -43,6 +43,7 @@ struct SearchStackEntry {
     inline void reset() {
         curr_pmove = PieceMove::none();
         excluded_move = Move::none();
+        reduction = 0;
         static_eval = SCORE_NONE;
         pv_list.clear();
     }
@@ -83,8 +84,6 @@ inline void unmake_move(ThreadData &td, const Move move) {
 inline void make_null_move(ThreadData &td) { td.position.make_null_move(); }
 
 inline void unmake_null_move(ThreadData &td) { td.position.unmake_null_move(); }
-
-ScoreType normalize_score(ScoreType score);
 
 ScoreType iterative_deepening(ThreadData &td);
 ScoreType aspiration(const CounterType &depth, const ScoreType prev_score, ThreadData &td);


### PR DESCRIPTION
```
Elo   | 0.41 +- 1.92 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 20498 W: 5053 L: 5029 D: 10416
Penta | [55, 1439, 7236, 1465, 54]
```
https://eduardomarinho.dev/test/847/