### PR TITLE
feat(search): LMR for one less move at root

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -538,7 +538,7 @@ ScoreType Engine::negamax(ScoreType alpha, ScoreType beta, CounterType depth, Co
         } else {
             int scaled_reduction = 0;
             // Late Move Reduction
-            if (moves_searched > 1 && depth >= 3 && move.is_quiet()) {
+            if (moves_searched > 1 + root && depth >= 3 && move.is_quiet()) {
                 scaled_reduction = LMR_TABLE[std::min(depth, 63)][std::min(moves_searched, 63)];
 
                 if (position.checkers_bb()) // Reduce less for moves that give check


### PR DESCRIPTION
### STC
```
Elo   | -1.22 +- 3.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.39 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11964 W: 2852 L: 2894 D: 6218
Penta | [56, 1440, 3028, 1406, 52]
```
https://eduardomarinho.dev/test/870/
### LTC
```
Elo   | 1.60 +- 1.75 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.15 (-2.25, 2.89) [0.00, 5.00]
Games | N: 36068 W: 8316 L: 8150 D: 19602
Penta | [30, 4117, 9568, 4295, 24]
```
https://eduardomarinho.dev/test/871/


Bench: 6000664

It scales!