### PR TITLE
feat(search): update correction history if upcoming repetition detected

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -246,6 +246,7 @@ ScoreType Engine::negamax(ScoreType alpha, ScoreType beta, CounterType depth, Co
     const bool singular_search = !excluded_move.is_none();
     Position &position = td.position;
     SearchStackEntry &node = td.search_stack[ply];
+    const bool in_check = position.in_check();
 
     // Early return conditions
     const bool root = ply == 0;
@@ -258,6 +259,12 @@ ScoreType Engine::negamax(ScoreType alpha, ScoreType beta, CounterType depth, Co
 
         // Upcoming repetition detection
         if (alpha < 0 && position.has_upcoming_repetition(ply)) {
+            if (!in_check) {
+                const ScoreType raw_eval = td.nnue.eval(td.position);
+                const HistoryType correction = td.correction_history.correction(td, ply);
+                const ScoreType adjusted_eval = adjust_eval(td.position, raw_eval, correction);
+                td.correction_history.update(td, depth, ply, 0 - adjusted_eval);
+            }
             alpha = 0;
             if (alpha >= beta)
                 return alpha;
@@ -299,7 +306,6 @@ ScoreType Engine::negamax(ScoreType alpha, ScoreType beta, CounterType depth, Co
         depth -= 1;
     }
 
-    const bool in_check = position.in_check();
     ScoreType eval, raw_eval;
     const ScoreType correction_value = td.correction_history.correction(td, ply);
     const ScoreType complexity = std::abs(correction_value);
@@ -636,8 +642,16 @@ ScoreType Engine::quiescence(ScoreType alpha, ScoreType beta, CounterType ply, T
     else if (ply >= MAX_SEARCH_DEPTH - 1)
         return position.in_check() ? 0 : td.nnue.eval(position);
 
+    const bool in_check = position.in_check();
+
     // Upcoming repetition detection
     if (alpha < 0 && position.has_upcoming_repetition(ply)) {
+        if (!in_check) {
+            const ScoreType raw_eval = td.nnue.eval(td.position);
+            const HistoryType correction = td.correction_history.correction(td, ply);
+            const ScoreType adjusted_eval = adjust_eval(td.position, raw_eval, correction);
+            td.correction_history.update(td, 1, ply, 0 - adjusted_eval);
+        }
         alpha = 0;
         if (alpha >= beta)
             return alpha;
@@ -663,7 +677,6 @@ ScoreType Engine::quiescence(ScoreType alpha, ScoreType beta, CounterType ply, T
         return ttscore;
     }
 
-    const bool in_check = position.in_check();
     ScoreType best_score, raw_eval;
     if (in_check) {
         node.static_eval = raw_eval = SCORE_NONE;


### PR DESCRIPTION
#### STC (unfinished)
```
Elo   | 0.83 +- 1.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.38 (-2.25, 2.89) [0.00, 5.00]
Games | N: 36330 W: 8761 L: 8674 D: 18895
Penta | [161, 4332, 9084, 4435, 153]
```
https://eduardomarinho.dev/test/882/

#### LTC
```
Elo   | 4.06 +- 3.00 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 12508 W: 2973 L: 2827 D: 6708
Penta | [10, 1408, 3272, 1554, 10]
```
https://eduardomarinho.dev/test/884/

Bench: 6987937



Idea by [kelseyde](https://github.com/kelseyde): https://github.com/kelseyde/hobbes-chess-engine/pull/422.
Very interesting patch!